### PR TITLE
Add support for ring buffer mode

### DIFF
--- a/imxvpuapi/imxvpuapi.h
+++ b/imxvpuapi/imxvpuapi.h
@@ -61,7 +61,7 @@ typedef unsigned long imx_vpu_phys_addr_t;
 typedef enum
 {
 	IMX_VPU_ALLOCATION_FLAG_WRITECOMBINE = (1UL << 0),
-	IMX_VPU_ALLOCATION_FLAG_UNCACHED	 = (1UL << 1)
+	IMX_VPU_ALLOCATION_FLAG_UNCACHED     = (1UL << 1)
 	/* XXX: When adding extra flags here, follow the pattern: IMX_VPU_ALLOCATION_FLAG_<NAME> = (1UL << <INDEX>) */
 }
 ImxVpuAllocationFlags;
@@ -75,7 +75,7 @@ typedef enum
 	/* Map memory for CPU write access */
 	IMX_VPU_MAPPING_FLAG_WRITE   = (1UL << 0),
 	/* Map memory for CPU read access */
-	IMX_VPU_MAPPING_FLAG_READ	= (1UL << 1)
+	IMX_VPU_MAPPING_FLAG_READ    = (1UL << 1)
 	/* XXX: When adding extra flags here, follow the pattern: IMX_VPU_MAPPING_FLAG_<NAME> = (1UL << <INDEX>) */
 }
 ImxVpuMappingFlags;
@@ -100,25 +100,25 @@ typedef struct _ImxVpuDMABufferAllocator ImxVpuDMABufferAllocator;
  * The vfuncs are:
  *
  * allocate(): Allocates a DMA buffer. "size" is the size of the buffer in bytes. "alignment" is the address
- *			 alignment in bytes. An alignment of 1 or 0 means that no alignment is required.
- *			 "flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case
- *			 cached pages are used by default). See ImxVpuAllocationFlags for a list of valid flags.
- *			 If allocation fails, NULL is returned.
+ *             alignment in bytes. An alignment of 1 or 0 means that no alignment is required.
+ *             "flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case
+ *             cached pages are used by default). See ImxVpuAllocationFlags for a list of valid flags.
+ *             If allocation fails, NULL is returned.
  *
  * deallocate(): Deallocates a DMA buffer. The buffer must have been allocated with the same allocator.
  *
  * map(): Maps a DMA buffer to the local address space, and returns the virtual address to this space.
- *		"flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case it will map
- *		in regular read/write mode). See ImxVpuMappingFlags for a list of valid flags.
+ *        "flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case it will map
+ *        in regular read/write mode). See ImxVpuMappingFlags for a list of valid flags.
  *
  * unmap(): Unmaps a DMA buffer. If the buffer isn't currently mapped, this function does nothing.
  *
  * get_fd(): Gets the file descriptor associated with the DMA buffer. This is the preferred way of interacting
- *		   with DMA buffers. If the underlying allocator does not support FDs, this function returns -1.
+ *           with DMA buffers. If the underlying allocator does not support FDs, this function returns -1.
  *
  * get_physical_address(): Gets the physical address associated with the DMA buffer. This address points to the
- *						 start of the buffer in the physical address space. If no physical addresses are
- *						 supported by the allocator, this function returns 0.
+ *                         start of the buffer in the physical address space. If no physical addresses are
+ *                         supported by the allocator, this function returns 0.
  *
  * get_size(): Returns the size of the buffer, in bytes.
  *
@@ -311,14 +311,14 @@ typedef enum
 	/* MPEG-1 part 2 and MPEG-2 part 2.
 	 *
 	 * Decoding: Fully compatible with the ISO/IEC 13182-2 specification and the main and high
-	 *		   profiles. Both progressive and interlaced content is supported.
+	 *           profiles. Both progressive and interlaced content is supported.
 	 */
 	IMX_VPU_CODEC_FORMAT_MPEG2 = 0,
 
 	/* MPEG-4 part 2.
 	 *
 	 * Decoding: Supports simple and advanced simple profile (except for GMC).
-	 *		   NOTE: DivX 3/5/6 are not supported and require special licensing by Freescale.
+	 *           NOTE: DivX 3/5/6 are not supported and require special licensing by Freescale.
 	 * Encoding: Supports the simple profile and max. level 5/6.
 	 */
 	IMX_VPU_CODEC_FORMAT_MPEG4,
@@ -333,17 +333,17 @@ typedef enum
 	/* h.264.
 	 *
 	 * Decoding: Supports baseline, main, high profiles, max. level 4.1.
-	 *		   (10-bit decoding is not supported.)
-	 *		   Only Annex.B byte-stream formatted input is supported.
+	 *           (10-bit decoding is not supported.)
+	 *           Only Annex.B byte-stream formatted input is supported.
 	 * Encoding: Supports baseline and constrained baseline profile, max. level 4.0.
-	 *		   Only Annex.B byte-stream formatted output is supported.
+	 *           Only Annex.B byte-stream formatted output is supported.
 	 */
 	IMX_VPU_CODEC_FORMAT_H264,
 
 	/* WMV3, also known as Windows Media Video 9. Compatible to VC-1 simple and main profiles.
 	 *
 	 * Decoding: Fully supported WMV3 decoding, excluding the deprecated WMV3 interlace support
-	 *		   (which has been obsoleted by the interlacing in the VC-1 advanced profile).
+	 *           (which has been obsoleted by the interlacing in the VC-1 advanced profile).
 	 * VC-1 advanced profile). */
 	IMX_VPU_CODEC_FORMAT_WMV3,
 
@@ -357,17 +357,17 @@ typedef enum
 	 *
 	 * Decoding: Only baseline JPEG frames are supported. Maximum resolution is 8192x8192.
 	 * Encoding: Only baseline JPEG frames are supported. Maximum resolution is 8192x8192.
-	 *		   NOTE: Encoder always operates in constant quality mode, even if the open
-	 *		   params have a nonzero bitrate set.
+	 *           NOTE: Encoder always operates in constant quality mode, even if the open
+	 *           params have a nonzero bitrate set.
 	 */
 	IMX_VPU_CODEC_FORMAT_MJPEG,
 
 	/* VP8.
 	 *
 	 * Decoding: fully compatible with the VP8 decoding specification.
-	 *		   Both simple and normal in-loop deblocking are supported.
-	 *		   NOTE: VPU specs state that the maximum supported resolution is 1280x720, but
-	 *		   tests show that up to 1920x1088 pixels do work.
+	 *           Both simple and normal in-loop deblocking are supported.
+	 *           NOTE: VPU specs state that the maximum supported resolution is 1280x720, but
+	 *           tests show that up to 1920x1088 pixels do work.
 	 */
 	IMX_VPU_CODEC_FORMAT_VP8
 
@@ -380,33 +380,33 @@ ImxVpuCodecFormat;
 typedef enum
 {
 	/* planar 4:2:0; if the chroma_interleave parameter is 1, the corresponding format is NV12, otherwise it is I420 */
-	IMX_VPU_COLOR_FORMAT_YUV420			= 0,
+	IMX_VPU_COLOR_FORMAT_YUV420            = 0,
 	/* planar 4:2:2; if the chroma_interleave parameter is 1, the corresponding format is NV16 */
 	IMX_VPU_COLOR_FORMAT_YUV422_HORIZONTAL = 1,
 	/* 4:2:2 vertical, actually 2:2:4 (according to the VPU docs); no corresponding format known for the chroma_interleave=1 case */
 	/* NOTE: this format is rarely used, and has only been seen in a few JPEG files */
 	IMX_VPU_COLOR_FORMAT_YUV422_VERTICAL   = 2,
 	/* planar 4:4:4; if the chroma_interleave parameter is 1, the corresponding format is NV24 */
-	IMX_VPU_COLOR_FORMAT_YUV444			= 3,
+	IMX_VPU_COLOR_FORMAT_YUV444            = 3,
 	/* 8-bit greayscale */
-	IMX_VPU_COLOR_FORMAT_YUV400			= 4
+	IMX_VPU_COLOR_FORMAT_YUV400            = 4
 }
 ImxVpuColorFormat;
 
 typedef enum
 {
-    IMX_VPU_ROTATE_0 = 0,
-    IMX_VPU_ROTATE_90 = 90,
-    IMX_VPU_ROTATE_180 = 180,
-    IMX_VPU_ROTATE_270 = 270
+	IMX_VPU_ROTATE_0   = 0,
+	IMX_VPU_ROTATE_90  = 90,
+	IMX_VPU_ROTATE_180 = 180,
+	IMX_VPU_ROTATE_270 = 270
 }ImxVpuRotateFlags;
 
 typedef enum
 {
-    IMX_VPU_MIRROR_NONE = 0,
-    IMX_VPU_MIRROR_VER,
-    IMX_VPU_MIRROR_HOR,
-    IMX_VPU_MIRROR_HOR_VER
+	IMX_VPU_MIRROR_NONE = 0,
+	IMX_VPU_MIRROR_VER,
+	IMX_VPU_MIRROR_HOR,
+	IMX_VPU_MIRROR_HOR_VER
 }ImxVpuMirrorFlags;
 
 /* Framebuffers are frame containers, and are used both for en- and decoding. */
@@ -595,9 +595,9 @@ char const *imx_vpu_frame_type_string(ImxVpuFrameType frame_type);
  *
  * Typically, loading/unloading is done in two ways:
  * (1) imx_dec_vpu_load() gets called in the startup phase of the process, and
- *	 imx_vpu_dec_unload() in the shutdown phase.
+ *     imx_vpu_dec_unload() in the shutdown phase.
  * (2) imx_dec_vpu_load() gets called every time before a decoder is to be created,
- *	 and imx_vpu_dec_unload() every time after a decoder was shut down.
+ *     and imx_vpu_dec_unload() every time after a decoder was shut down.
  *
  * Both methods are fine; however, for (2), it is important to keep in mind that
  * the imx_vpu_dec_load() / imx_vpu_dec_unload() functions are *not* thread safe,
@@ -605,59 +605,59 @@ char const *imx_vpu_frame_type_string(ImxVpuFrameType frame_type);
  *
  * How to create, use, and shutdown a decoder:
  * 1. Call imx_vpu_dec_get_bitstream_buffer_info(), and allocate a DMA buffer
- *	with the given size and alignment. This is the minimum required size.
- *	The buffer can be larger, but must not be smaller than the given size.
+ *    with the given size and alignment. This is the minimum required size.
+ *    The buffer can be larger, but must not be smaller than the given size.
  * 2. Fill an instance of ImxVpuDecOpenParams with the values specific to the
- *	input data. Check the documentation of ImxVpuDecOpenParams for details
- *	about its fields.
+ *    input data. Check the documentation of ImxVpuDecOpenParams for details
+ *    about its fields.
  * 3. Call imx_vpu_dec_open(), passing in a pointer to the filled ImxVpuDecOpenParams
- *	instance, the bitstream DMA buffer which was allocated in step 1, a callback
- *	of type imx_vpu_dec_new_initial_info_callback, and a user defined pointer
- *	that is passed to the callback (if not needed, just set it to NULL).
+ *    instance, the bitstream DMA buffer which was allocated in step 1, a callback
+ *    of type imx_vpu_dec_new_initial_info_callback, and a user defined pointer
+ *    that is passed to the callback (if not needed, just set it to NULL).
  * 4. If out-of-band codec data is present, set it with imx_vpu_dec_set_codec_data().
  * 5. Call imx_vpu_dec_decode(), and push data to it. Once initial information about
- *	the bitstream becomes available, the callback from step 3 is invoked.
+ *    the bitstream becomes available, the callback from step 3 is invoked.
  * 6. Inside the callback, the new initial info is available. The new_initial_info pointer
- *	is never NULL. In this callback, framebuffers are allocated and registered, as
- *	explained in the next steps. Steps 7-9 are performed inside the callback.
+ *    is never NULL. In this callback, framebuffers are allocated and registered, as
+ *    explained in the next steps. Steps 7-9 are performed inside the callback.
  * 7. (Optional) Perform the necessary size and alignment calculations by calling
- *	imx_vpu_calc_framebuffer_sizes(). Pass in either the frame width & height from
- *	ImxVpuDecInitialInfo , or some explicit values that were determined externally.
- *	(The width & height do not have to be aligned; the function does this automatically.)
+ *    imx_vpu_calc_framebuffer_sizes(). Pass in either the frame width & height from
+ *    ImxVpuDecInitialInfo , or some explicit values that were determined externally.
+ *    (The width & height do not have to be aligned; the function does this automatically.)
  * 8. Create an array of at least as many ImxVpuFramebuffer instances as specified in
- *	min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
- *	enough to hold a raw decoded frame. If step 7 was performed, allocating as many bytes
- *	as indicated by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each
- *	ImxVpuFramebuffer instance are valid. Using the imx_vpu_fill_framebuffer_params()
- *	convenience function for this is strongly recommended.
+ *    min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
+ *    enough to hold a raw decoded frame. If step 7 was performed, allocating as many bytes
+ *    as indicated by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each
+ *    ImxVpuFramebuffer instance are valid. Using the imx_vpu_fill_framebuffer_params()
+ *    convenience function for this is strongly recommended.
  * 9. Call imx_vpu_dec_register_framebuffers() and pass in the ImxVpuFramebuffer array
- *	and the number of ImxVpuFramebuffer instances.
- *	Note that this call does _not_ copy the framebuffer array, it just stores the pointer
- *	to it internally, so make sure the array is valid until the decoder is closed!
- *	This should be the last action in the callback.
+ *    and the number of ImxVpuFramebuffer instances.
+ *    Note that this call does _not_ copy the framebuffer array, it just stores the pointer
+ *    to it internally, so make sure the array is valid until the decoder is closed!
+ *    This should be the last action in the callback.
  * 10. Continue calling imx_vpu_dec_decode(). Make sure the input data is not NULL.
- *	 If the IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE flag is set in the output code,
- *	 call imx_vpu_dec_get_decoded_frame() with a pointer to an ImxVpuRawFrame instance.
- *	 The instance will get filled by the function with information about the decoded frame.
- *	 Once the decoded frame has been processed by the user, it is important to call
- *	 imx_vpu_dec_mark_framebuffer_as_displayed() to let the decoder know that the
- *	 framebuffer is available for storing new decoded frames again.
- *	 If IMX_VPU_DEC_OUTPUT_CODE_DROPPED is set, it is possible to retrieve information about
- *	 the dropped frame (context pointer, PTS/DTS values) with imx_vpu_dec_get_dropped_frame_info().
- *	 If IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns a value other
- *	 than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
+ *     If the IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE flag is set in the output code,
+ *     call imx_vpu_dec_get_decoded_frame() with a pointer to an ImxVpuRawFrame instance.
+ *     The instance will get filled by the function with information about the decoded frame.
+ *     Once the decoded frame has been processed by the user, it is important to call
+ *     imx_vpu_dec_mark_framebuffer_as_displayed() to let the decoder know that the
+ *     framebuffer is available for storing new decoded frames again.
+ *     If IMX_VPU_DEC_OUTPUT_CODE_DROPPED is set, it is possible to retrieve information about
+ *     the dropped frame (context pointer, PTS/DTS values) with imx_vpu_dec_get_dropped_frame_info().
+ *     If IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns a value other
+ *     than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
  * 11. In case a flush/reset is desired (typically after seeking), call imx_vpu_dec_flush().
- *	 Note that any internal context/PTS/DTS values from the encoded and raw frames will be thrown
- *	 away after this call; if for example the context is an index, the system that hands
- *	 out the indices should be informed that any previously handed out index is now unused.
+ *     Note that any internal context/PTS/DTS values from the encoded and raw frames will be thrown
+ *     away after this call; if for example the context is an index, the system that hands
+ *     out the indices should be informed that any previously handed out index is now unused.
  * 12. When there is no more incoming data, and pending decoded frames need to be retrieved
- *	 from the decoder, enable drain mode with imx_vpu_dec_enable_drain_mode(). This is
- *	 typically necessary when the data source reached its end, playback is finishing, and
- *	 there is a delay of N frames at the beginning.
- *	 After this call, continue calling imx_vpu_dec_decode() to retrieve the pending
- *	 decoded frames, but the data and the codec data pointers of encoded_framt must be NULL.
- *	 As in step 10, if IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns
- *	 a value other than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
+ *     from the decoder, enable drain mode with imx_vpu_dec_enable_drain_mode(). This is
+ *     typically necessary when the data source reached its end, playback is finishing, and
+ *     there is a delay of N frames at the beginning.
+ *     After this call, continue calling imx_vpu_dec_decode() to retrieve the pending
+ *     decoded frames, but the data and the codec data pointers of encoded_framt must be NULL.
+ *     As in step 10, if IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns
+ *     a value other than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
  * 13. After playback is finished, close the decoder with imx_vpu_dec_close().
  * 14. Deallocate framebuffer memory blocks and the bitstream buffer memory block.
  *
@@ -669,10 +669,10 @@ char const *imx_vpu_frame_type_string(ImxVpuFrameType frame_type);
  *   mutex_lock(&mutex);
  *
  *   while (dec_initialized && !imx_vpu_dec_check_if_can_decode(decode) && !abort_waiting)
- *	 condition_wait(&condition_variable, &mutex);
+ *     condition_wait(&condition_variable, &mutex);
  *
  *   if (!abort_waiting)
- *	 imx_vpu_dec_decode(decoder, encoded_frame, &output_code);
+ *     imx_vpu_dec_decode(decoder, encoded_frame, &output_code);
  *   ...
  *
  *   mutex_unlock(&mutex);
@@ -763,30 +763,30 @@ typedef enum
 	 * fslwrapper backend; however, with the vpulib backend, it will
 	 * always use the input unless an error occurs or EOS is signaled
 	 * in drain mode. */
-	IMX_VPU_DEC_OUTPUT_CODE_INPUT_USED				   = (1UL << 0),
+	IMX_VPU_DEC_OUTPUT_CODE_INPUT_USED                 = (1UL << 0),
 	/* EOS was reached; no more unfinished frames are queued internally.
 	 * This can be reached either by bitstreams with no frame delay,
 	 * or by running the decoder in drain mode (enabled by calling
 	 * imx_vpu_dec_enable_drain_mode() ).
 	 */
-	IMX_VPU_DEC_OUTPUT_CODE_EOS						  = (1UL << 1),
+	IMX_VPU_DEC_OUTPUT_CODE_EOS                        = (1UL << 1),
 	/* A fully decoded frame is now available, and can be retrieved
 	 * by calling imx_vpu_dec_get_decoded_frame(). */
-	IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE	  = (1UL << 2),
+	IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE    = (1UL << 2),
 	/* A frame was dropped by the decoder. The dropped frame's
 	 * context, PTS, DTS values can be retrieved by calling
 	 * imx_vpu_dec_get_dropped_frame_info(). */
-	IMX_VPU_DEC_OUTPUT_CODE_DROPPED					  = (1UL << 3),
+	IMX_VPU_DEC_OUTPUT_CODE_DROPPED                    = (1UL << 3),
 	/* There aren't enough free framebuffers available for decoding.
 	 * This usually happens when imx_vpu_dec_mark_framebuffer_as_displayed()
 	 * wasn't called before imx_vpu_dec_decode(), which can occur in
 	 * multithreaded environments. imx_vpu_dec_check_if_can_decode() is useful
 	 * to avoid this. Also see the guide above for more. */
-	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_OUTPUT_FRAMES	 = (1UL << 4),
+	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_OUTPUT_FRAMES   = (1UL << 4),
 	/* Input data for a frame is incomplete. No decoded frame will
 	 * be available until the input frame's data has been fully and
 	 * correctly delivered. */
-	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_INPUT_DATA		= (1UL << 5),
+	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_INPUT_DATA      = (1UL << 5),
 	/* The VPU detected a change in the video sequence parameters
 	 * (like frame width and height). Decoding cannot continue. See the
 	 * explanation in the step-by-step guide above for what steps to take
@@ -795,7 +795,7 @@ typedef enum
 	 * that this flag is set immediately when input data with param changes
 	 * is fed to the decoder, even if this is for example a h.264 high
 	 * profile stream with lots of frame reordering and frame delays. */
-	IMX_VPU_DEC_OUTPUT_CODE_VIDEO_PARAMS_CHANGED		 = (1UL << 6)
+	IMX_VPU_DEC_OUTPUT_CODE_VIDEO_PARAMS_CHANGED       = (1UL << 6)
 }
 ImxVpuDecOutputCodes;
 
@@ -1003,9 +1003,9 @@ ImxVpuDecReturnCodes imx_vpu_dec_mark_framebuffer_as_displayed(ImxVpuDecoder *de
  *
  * Typically, loading/unloading is done in two ways:
  * (1) imx_vpu_enc_load() gets called in the startup phase of the process, and
- *	 imx_vpu_enc_unload() in the shutdown phase.
+ *     imx_vpu_enc_unload() in the shutdown phase.
  * (2) imx_vpu_enc_load() gets called every time before a encoder is to be created,
- *	 and imx_vpu_enc_unload() every time after a encoder was shut down.
+ *     and imx_vpu_enc_unload() every time after a encoder was shut down.
  *
  * Both methods are fine; however, for (2), it is important to keep in mind that
  * the imx_vpu_enc_load() / imx_vpu_enc_unload() functions are *not* thread safe,
@@ -1013,69 +1013,69 @@ ImxVpuDecReturnCodes imx_vpu_dec_mark_framebuffer_as_displayed(ImxVpuDecoder *de
  *
  * How to create, use, and shutdown an encoder:
  * 1. Call imx_vpu_enc_get_bitstream_buffer_info(), and allocate a DMA buffer
- *	with the given size and alignment. This is the minimum required size.
- *	The buffer can be larger, but must not be smaller than the given size.
+ *    with the given size and alignment. This is the minimum required size.
+ *    The buffer can be larger, but must not be smaller than the given size.
  * 2. Fill an instance of ImxVpuEncOpenParams with the values specific to the
- *	input data. Check the documentation of ImxVpuEncOpenParams for details
- *	about its fields. It is recommended to set default values by calling
- *	imx_vpu_enc_set_default_open_params() and afterwards set any explicit valus.
+ *    input data. Check the documentation of ImxVpuEncOpenParams for details
+ *    about its fields. It is recommended to set default values by calling
+ *    imx_vpu_enc_set_default_open_params() and afterwards set any explicit valus.
  * 3. Call imx_vpu_enc_open(), passing in a pointer to the filled ImxVpuEncOpenParams
- *	instance, and the DMA buffer of the bitstream DMA buffer which was allocated in
- *	step 1.
+ *    instance, and the DMA buffer of the bitstream DMA buffer which was allocated in
+ *    step 1.
  * 4. Call imx_vpu_enc_get_initial_info(). The encoder's initial info contains the
- *	minimum number of framebuffers that must be allocated and registered, and the
- *	address alignment that must be used when allocating DMA memory  for these
- *	framebuffers.
+ *    minimum number of framebuffers that must be allocated and registered, and the
+ *    address alignment that must be used when allocating DMA memory  for these
+ *    framebuffers.
  * 5. (Optional) Perform the necessary size and alignment calculations by calling
- *	imx_vpu_calc_framebuffer_sizes(). Pass in the width & height of the frames that
- *	shall be encoded. (The width & height do not have to be aligned; the function
- *	does this automatically.)
+ *    imx_vpu_calc_framebuffer_sizes(). Pass in the width & height of the frames that
+ *    shall be encoded. (The width & height do not have to be aligned; the function
+ *    does this automatically.)
  * 6. Create an array of at least as many ImxVpuFramebuffer instances as specified in
- *	min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
- *	enough to hold a frame. If step 5 was performed, allocating as many bytes as indicated
- *	by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each ImxVpuFramebuffer
- *	instance are valid. Using the imx_vpu_fill_framebuffer_params() convenience function
- *	for this is recommended. Note that these framebuffers are used for temporary internal
- *	encoding only, and will not contain input or output data.
+ *    min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
+ *    enough to hold a frame. If step 5 was performed, allocating as many bytes as indicated
+ *    by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each ImxVpuFramebuffer
+ *    instance are valid. Using the imx_vpu_fill_framebuffer_params() convenience function
+ *    for this is recommended. Note that these framebuffers are used for temporary internal
+ *    encoding only, and will not contain input or output data.
  * 7. Call imx_vpu_enc_register_framebuffers() and pass in the ImxVpuFramebuffer array
- *	and the number of ImxVpuFramebuffer instances allocated in step 6.
+ *    and the number of ImxVpuFramebuffer instances allocated in step 6.
  * 8. (Optional) allocate a DMA buffer for the input frames. Only one buffer is necessary.
- *	Simply reuse the sizes used for the temporary buffers in step 7. If the incoming data
- *	is already stored in DMA buffers, this step can be omitted, since the encoder can then
- *	read the data directly.
+ *    Simply reuse the sizes used for the temporary buffers in step 7. If the incoming data
+ *    is already stored in DMA buffers, this step can be omitted, since the encoder can then
+ *    read the data directly.
  * 9. Create an instance of ImxVpuRawFrame, set its values to zero (typically by using memset()).
  * 10. Create an instance of ImxVpuEncodedFrame. Set its values to zero (typically by using memset()).
  * 11. Set the framebuffer pointer of the ImxVpuRawFrame's instance from step 9 to refer to the
- *	 input DMA buffer (either the one allocated in step 8, or the one containing the input data if
- *	 it already comes in DMA memory).
+ *     input DMA buffer (either the one allocated in step 8, or the one containing the input data if
+ *     it already comes in DMA memory).
  * 12. Fill an instance of ImxVpuEncParams with valid values. It is recommended to first set its
- *	 values to zero by using memset() and then call imx_vpu_enc_set_default_encoding_params()
- *	 to set default values. It is essential to make sure the acquire_output_buffer() and
- *	 finish_output_buffer() function pointers are set, as these are used for acquiring buffers
- *	 to write encoded output data into.
+ *     values to zero by using memset() and then call imx_vpu_enc_set_default_encoding_params()
+ *     to set default values. It is essential to make sure the acquire_output_buffer() and
+ *     finish_output_buffer() function pointers are set, as these are used for acquiring buffers
+ *     to write encoded output data into.
  * 13. If step 8 was performed, and therefore input data does *not* come in DMA memory, copy the
- *	 pixels from the raw input frames into the DMA buffer allocated in step 8. Otherwise, if
- *	 the raw input frames are already stored in DMA memory, this step can be omitted.
+ *     pixels from the raw input frames into the DMA buffer allocated in step 8. Otherwise, if
+ *     the raw input frames are already stored in DMA memory, this step can be omitted.
  * 14. Call imx_vpu_enc_encode(). Pass the raw frame, the encoded frame, and the encoding param
- *	 strucutres from steps 9, 10, and 12 to it.
- *	 This function will encode data, and acquire an output buffer to write the encoded data into
- *	 by using the acquire_output_buffer() function pointer set in step 12. Once it is done
- *	 encoding, it will call the finish_output_buffer() function from step 12. Any handle created
- *	 by acquire_output_buffer() will be copied over to the encoded data frame structure. When
- *	 imx_vpu_enc_encode() exits, this handle can then be used to further process the output data.
- *	 It is guaranteed that once acquire_output_buffer() was called, finish_output_buffer() will
- *	 be called, even if an error occurred.
- *	 The IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE output code bit will always be set
- *	 unless the function returned a code other than IMX_VPU_ENC_RETURN_CODE_OK.
- *	 If the IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER bit is set, then header data has been
- *	 written in the output memory block allocated in step 10. It is placed right before the
- *	 actual encoded frame data. imx_vpu_enc_encode() will pass over the combined size of the header
- *	 and the encoded frame data to acquire_output_buffer() in this case, ensuring that the output
- *	 buffers are big enough.
+ *     strucutres from steps 9, 10, and 12 to it.
+ *     This function will encode data, and acquire an output buffer to write the encoded data into
+ *     by using the acquire_output_buffer() function pointer set in step 12. Once it is done
+ *     encoding, it will call the finish_output_buffer() function from step 12. Any handle created
+ *     by acquire_output_buffer() will be copied over to the encoded data frame structure. When
+ *     imx_vpu_enc_encode() exits, this handle can then be used to further process the output data.
+ *     It is guaranteed that once acquire_output_buffer() was called, finish_output_buffer() will
+ *     be called, even if an error occurred.
+ *     The IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE output code bit will always be set
+ *     unless the function returned a code other than IMX_VPU_ENC_RETURN_CODE_OK.
+ *     If the IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER bit is set, then header data has been
+ *     written in the output memory block allocated in step 10. It is placed right before the
+ *     actual encoded frame data. imx_vpu_enc_encode() will pass over the combined size of the header
+ *     and the encoded frame data to acquire_output_buffer() in this case, ensuring that the output
+ *     buffers are big enough.
  * 15. Repeat steps 11 to 14 until there are no more frames to encode or an error occurs.
  * 16. After encoding is finished, close the encoder with imx_vpu_enc_close().
  * 17. Deallocate framebuffer memory blocks, the input DMA buffer block, the output memory block,
- *	 and the bitstream buffer memory block.
+ *     and the bitstream buffer memory block.
  *
  * Note that the encoder does not use any kind of frame reordering. h.264 data uses the
  * baseline profile. An input frame immediately results in an output frame (unless an error occured).
@@ -1130,15 +1130,15 @@ typedef enum
 	 * should be loaded. If this code is not present, then the encoder
 	 * didn't use it yet, so give it to the encoder again until this
 	 * code is set or an error is returned. */
-	IMX_VPU_ENC_OUTPUT_CODE_INPUT_USED				 = (1UL << 0),
+	IMX_VPU_ENC_OUTPUT_CODE_INPUT_USED              = (1UL << 0),
 	/* A fully encoded frame is now available. The encoded_frame argument
 	 * passed to imx_vpu_enc_encode() contains information about this frame. */
-	IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE	= (1UL << 1),
+	IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE = (1UL << 1),
 	/* The data in the encoded frame also contains header information
 	 * like SPS/PSS for h.264. Headers are always placed at the beginning
 	 * of the encoded data, and this code is never present if the
 	 * IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE isn't set. */
-	IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER			= (1UL << 2)
+	IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER         = (1UL << 2)
 }
 ImxVpuEncOutputCodes;
 
@@ -1485,7 +1485,7 @@ typedef struct
 	 * ImxVpuEncOpenParams). Default value is 0. */
 	int enable_autoskip;
 
-    /* Set the mirroring for the frame. */
+	/* Set the mirroring for the frame. */
 	ImxVpuMirrorFlags mirrorFlags;
 
 	/* Functions for acquiring and finishing output buffers. See the

--- a/imxvpuapi/imxvpuapi.h
+++ b/imxvpuapi/imxvpuapi.h
@@ -61,7 +61,7 @@ typedef unsigned long imx_vpu_phys_addr_t;
 typedef enum
 {
 	IMX_VPU_ALLOCATION_FLAG_WRITECOMBINE = (1UL << 0),
-	IMX_VPU_ALLOCATION_FLAG_UNCACHED     = (1UL << 1)
+	IMX_VPU_ALLOCATION_FLAG_UNCACHED	 = (1UL << 1)
 	/* XXX: When adding extra flags here, follow the pattern: IMX_VPU_ALLOCATION_FLAG_<NAME> = (1UL << <INDEX>) */
 }
 ImxVpuAllocationFlags;
@@ -75,7 +75,7 @@ typedef enum
 	/* Map memory for CPU write access */
 	IMX_VPU_MAPPING_FLAG_WRITE   = (1UL << 0),
 	/* Map memory for CPU read access */
-	IMX_VPU_MAPPING_FLAG_READ    = (1UL << 1)
+	IMX_VPU_MAPPING_FLAG_READ	= (1UL << 1)
 	/* XXX: When adding extra flags here, follow the pattern: IMX_VPU_MAPPING_FLAG_<NAME> = (1UL << <INDEX>) */
 }
 ImxVpuMappingFlags;
@@ -101,25 +101,25 @@ typedef struct _ImxVpuDMABufferAllocator ImxVpuDMABufferAllocator;
  * The vfuncs are:
  *
  * allocate(): Allocates a DMA buffer. "size" is the size of the buffer in bytes. "alignment" is the address
- *             alignment in bytes. An alignment of 1 or 0 means that no alignment is required.
- *             "flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case
- *             cached pages are used by default). See ImxVpuAllocationFlags for a list of valid flags.
- *             If allocation fails, NULL is returned.
+ *			 alignment in bytes. An alignment of 1 or 0 means that no alignment is required.
+ *			 "flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case
+ *			 cached pages are used by default). See ImxVpuAllocationFlags for a list of valid flags.
+ *			 If allocation fails, NULL is returned.
  *
  * deallocate(): Deallocates a DMA buffer. The buffer must have been allocated with the same allocator.
  *
  * map(): Maps a DMA buffer to the local address space, and returns the virtual address to this space.
- *        "flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case it will map
- *        in regular read/write mode). See ImxVpuMappingFlags for a list of valid flags.
+ *		"flags" is a bitwise OR combination of flags (or 0 if no flags are used, in which case it will map
+ *		in regular read/write mode). See ImxVpuMappingFlags for a list of valid flags.
  *
  * unmap(): Unmaps a DMA buffer. If the buffer isn't currently mapped, this function does nothing.
  *
  * get_fd(): Gets the file descriptor associated with the DMA buffer. This is the preferred way of interacting
- *           with DMA buffers. If the underlying allocator does not support FDs, this function returns -1.
+ *		   with DMA buffers. If the underlying allocator does not support FDs, this function returns -1.
  *
  * get_physical_address(): Gets the physical address associated with the DMA buffer. This address points to the
- *                         start of the buffer in the physical address space. If no physical addresses are
- *                         supported by the allocator, this function returns 0.
+ *						 start of the buffer in the physical address space. If no physical addresses are
+ *						 supported by the allocator, this function returns 0.
  *
  * get_size(): Returns the size of the buffer, in bytes.
  *
@@ -312,14 +312,14 @@ typedef enum
 	/* MPEG-1 part 2 and MPEG-2 part 2.
 	 *
 	 * Decoding: Fully compatible with the ISO/IEC 13182-2 specification and the main and high
-	 *           profiles. Both progressive and interlaced content is supported.
+	 *		   profiles. Both progressive and interlaced content is supported.
 	 */
 	IMX_VPU_CODEC_FORMAT_MPEG2 = 0,
 
 	/* MPEG-4 part 2.
 	 *
 	 * Decoding: Supports simple and advanced simple profile (except for GMC).
-	 *           NOTE: DivX 3/5/6 are not supported and require special licensing by Freescale.
+	 *		   NOTE: DivX 3/5/6 are not supported and require special licensing by Freescale.
 	 * Encoding: Supports the simple profile and max. level 5/6.
 	 */
 	IMX_VPU_CODEC_FORMAT_MPEG4,
@@ -334,17 +334,17 @@ typedef enum
 	/* h.264.
 	 *
 	 * Decoding: Supports baseline, main, high profiles, max. level 4.1.
-	 *           (10-bit decoding is not supported.)
-	 *           Only Annex.B byte-stream formatted input is supported.
+	 *		   (10-bit decoding is not supported.)
+	 *		   Only Annex.B byte-stream formatted input is supported.
 	 * Encoding: Supports baseline and constrained baseline profile, max. level 4.0.
-	 *           Only Annex.B byte-stream formatted output is supported.
+	 *		   Only Annex.B byte-stream formatted output is supported.
 	 */
 	IMX_VPU_CODEC_FORMAT_H264,
 
 	/* WMV3, also known as Windows Media Video 9. Compatible to VC-1 simple and main profiles.
 	 *
 	 * Decoding: Fully supported WMV3 decoding, excluding the deprecated WMV3 interlace support
-	 *           (which has been obsoleted by the interlacing in the VC-1 advanced profile).
+	 *		   (which has been obsoleted by the interlacing in the VC-1 advanced profile).
 	 * VC-1 advanced profile). */
 	IMX_VPU_CODEC_FORMAT_WMV3,
 
@@ -358,17 +358,17 @@ typedef enum
 	 *
 	 * Decoding: Only baseline JPEG frames are supported. Maximum resolution is 8192x8192.
 	 * Encoding: Only baseline JPEG frames are supported. Maximum resolution is 8192x8192.
-	 *           NOTE: Encoder always operates in constant quality mode, even if the open
-	 *           params have a nonzero bitrate set.
+	 *		   NOTE: Encoder always operates in constant quality mode, even if the open
+	 *		   params have a nonzero bitrate set.
 	 */
 	IMX_VPU_CODEC_FORMAT_MJPEG,
 
 	/* VP8.
 	 *
 	 * Decoding: fully compatible with the VP8 decoding specification.
-	 *           Both simple and normal in-loop deblocking are supported.
-	 *           NOTE: VPU specs state that the maximum supported resolution is 1280x720, but
-	 *           tests show that up to 1920x1088 pixels do work.
+	 *		   Both simple and normal in-loop deblocking are supported.
+	 *		   NOTE: VPU specs state that the maximum supported resolution is 1280x720, but
+	 *		   tests show that up to 1920x1088 pixels do work.
 	 */
 	IMX_VPU_CODEC_FORMAT_VP8
 
@@ -381,16 +381,16 @@ ImxVpuCodecFormat;
 typedef enum
 {
 	/* planar 4:2:0; if the chroma_interleave parameter is 1, the corresponding format is NV12, otherwise it is I420 */
-	IMX_VPU_COLOR_FORMAT_YUV420            = 0,
+	IMX_VPU_COLOR_FORMAT_YUV420			= 0,
 	/* planar 4:2:2; if the chroma_interleave parameter is 1, the corresponding format is NV16 */
 	IMX_VPU_COLOR_FORMAT_YUV422_HORIZONTAL = 1,
 	/* 4:2:2 vertical, actually 2:2:4 (according to the VPU docs); no corresponding format known for the chroma_interleave=1 case */
 	/* NOTE: this format is rarely used, and has only been seen in a few JPEG files */
 	IMX_VPU_COLOR_FORMAT_YUV422_VERTICAL   = 2,
 	/* planar 4:4:4; if the chroma_interleave parameter is 1, the corresponding format is NV24 */
-	IMX_VPU_COLOR_FORMAT_YUV444            = 3,
+	IMX_VPU_COLOR_FORMAT_YUV444			= 3,
 	/* 8-bit greayscale */
-	IMX_VPU_COLOR_FORMAT_YUV400            = 4
+	IMX_VPU_COLOR_FORMAT_YUV400			= 4
 }
 ImxVpuColorFormat;
 
@@ -581,9 +581,9 @@ char const *imx_vpu_frame_type_string(ImxVpuFrameType frame_type);
  *
  * Typically, loading/unloading is done in two ways:
  * (1) imx_dec_vpu_load() gets called in the startup phase of the process, and
- *     imx_vpu_dec_unload() in the shutdown phase.
+ *	 imx_vpu_dec_unload() in the shutdown phase.
  * (2) imx_dec_vpu_load() gets called every time before a decoder is to be created,
- *     and imx_vpu_dec_unload() every time after a decoder was shut down.
+ *	 and imx_vpu_dec_unload() every time after a decoder was shut down.
  *
  * Both methods are fine; however, for (2), it is important to keep in mind that
  * the imx_vpu_dec_load() / imx_vpu_dec_unload() functions are *not* thread safe,
@@ -591,59 +591,59 @@ char const *imx_vpu_frame_type_string(ImxVpuFrameType frame_type);
  *
  * How to create, use, and shutdown a decoder:
  * 1. Call imx_vpu_dec_get_bitstream_buffer_info(), and allocate a DMA buffer
- *    with the given size and alignment. This is the minimum required size.
- *    The buffer can be larger, but must not be smaller than the given size.
+ *	with the given size and alignment. This is the minimum required size.
+ *	The buffer can be larger, but must not be smaller than the given size.
  * 2. Fill an instance of ImxVpuDecOpenParams with the values specific to the
- *    input data. Check the documentation of ImxVpuDecOpenParams for details
- *    about its fields.
+ *	input data. Check the documentation of ImxVpuDecOpenParams for details
+ *	about its fields.
  * 3. Call imx_vpu_dec_open(), passing in a pointer to the filled ImxVpuDecOpenParams
- *    instance, the bitstream DMA buffer which was allocated in step 1, a callback
- *    of type imx_vpu_dec_new_initial_info_callback, and a user defined pointer
- *    that is passed to the callback (if not needed, just set it to NULL).
+ *	instance, the bitstream DMA buffer which was allocated in step 1, a callback
+ *	of type imx_vpu_dec_new_initial_info_callback, and a user defined pointer
+ *	that is passed to the callback (if not needed, just set it to NULL).
  * 4. If out-of-band codec data is present, set it with imx_vpu_dec_set_codec_data().
  * 5. Call imx_vpu_dec_decode(), and push data to it. Once initial information about
- *    the bitstream becomes available, the callback from step 3 is invoked.
+ *	the bitstream becomes available, the callback from step 3 is invoked.
  * 6. Inside the callback, the new initial info is available. The new_initial_info pointer
- *    is never NULL. In this callback, framebuffers are allocated and registered, as
- *    explained in the next steps. Steps 7-9 are performed inside the callback.
+ *	is never NULL. In this callback, framebuffers are allocated and registered, as
+ *	explained in the next steps. Steps 7-9 are performed inside the callback.
  * 7. (Optional) Perform the necessary size and alignment calculations by calling
- *    imx_vpu_calc_framebuffer_sizes(). Pass in either the frame width & height from
- *    ImxVpuDecInitialInfo , or some explicit values that were determined externally.
- *    (The width & height do not have to be aligned; the function does this automatically.)
+ *	imx_vpu_calc_framebuffer_sizes(). Pass in either the frame width & height from
+ *	ImxVpuDecInitialInfo , or some explicit values that were determined externally.
+ *	(The width & height do not have to be aligned; the function does this automatically.)
  * 8. Create an array of at least as many ImxVpuFramebuffer instances as specified in
- *    min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
- *    enough to hold a raw decoded frame. If step 7 was performed, allocating as many bytes
- *    as indicated by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each
- *    ImxVpuFramebuffer instance are valid. Using the imx_vpu_fill_framebuffer_params()
- *    convenience function for this is strongly recommended.
+ *	min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
+ *	enough to hold a raw decoded frame. If step 7 was performed, allocating as many bytes
+ *	as indicated by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each
+ *	ImxVpuFramebuffer instance are valid. Using the imx_vpu_fill_framebuffer_params()
+ *	convenience function for this is strongly recommended.
  * 9. Call imx_vpu_dec_register_framebuffers() and pass in the ImxVpuFramebuffer array
- *    and the number of ImxVpuFramebuffer instances.
- *    Note that this call does _not_ copy the framebuffer array, it just stores the pointer
- *    to it internally, so make sure the array is valid until the decoder is closed!
- *    This should be the last action in the callback.
+ *	and the number of ImxVpuFramebuffer instances.
+ *	Note that this call does _not_ copy the framebuffer array, it just stores the pointer
+ *	to it internally, so make sure the array is valid until the decoder is closed!
+ *	This should be the last action in the callback.
  * 10. Continue calling imx_vpu_dec_decode(). Make sure the input data is not NULL.
- *     If the IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE flag is set in the output code,
- *     call imx_vpu_dec_get_decoded_frame() with a pointer to an ImxVpuRawFrame instance.
- *     The instance will get filled by the function with information about the decoded frame.
- *     Once the decoded frame has been processed by the user, it is important to call
- *     imx_vpu_dec_mark_framebuffer_as_displayed() to let the decoder know that the
- *     framebuffer is available for storing new decoded frames again.
- *     If IMX_VPU_DEC_OUTPUT_CODE_DROPPED is set, it is possible to retrieve information about
- *     the dropped frame (context pointer, PTS/DTS values) with imx_vpu_dec_get_dropped_frame_info().
- *     If IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns a value other
- *     than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
+ *	 If the IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE flag is set in the output code,
+ *	 call imx_vpu_dec_get_decoded_frame() with a pointer to an ImxVpuRawFrame instance.
+ *	 The instance will get filled by the function with information about the decoded frame.
+ *	 Once the decoded frame has been processed by the user, it is important to call
+ *	 imx_vpu_dec_mark_framebuffer_as_displayed() to let the decoder know that the
+ *	 framebuffer is available for storing new decoded frames again.
+ *	 If IMX_VPU_DEC_OUTPUT_CODE_DROPPED is set, it is possible to retrieve information about
+ *	 the dropped frame (context pointer, PTS/DTS values) with imx_vpu_dec_get_dropped_frame_info().
+ *	 If IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns a value other
+ *	 than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
  * 11. In case a flush/reset is desired (typically after seeking), call imx_vpu_dec_flush().
- *     Note that any internal context/PTS/DTS values from the encoded and raw frames will be thrown
- *     away after this call; if for example the context is an index, the system that hands
- *     out the indices should be informed that any previously handed out index is now unused.
+ *	 Note that any internal context/PTS/DTS values from the encoded and raw frames will be thrown
+ *	 away after this call; if for example the context is an index, the system that hands
+ *	 out the indices should be informed that any previously handed out index is now unused.
  * 12. When there is no more incoming data, and pending decoded frames need to be retrieved
- *     from the decoder, enable drain mode with imx_vpu_dec_enable_drain_mode(). This is
- *     typically necessary when the data source reached its end, playback is finishing, and
- *     there is a delay of N frames at the beginning.
- *     After this call, continue calling imx_vpu_dec_decode() to retrieve the pending
- *     decoded frames, but the data and the codec data pointers of encoded_framt must be NULL.
- *     As in step 10, if IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns
- *     a value other than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
+ *	 from the decoder, enable drain mode with imx_vpu_dec_enable_drain_mode(). This is
+ *	 typically necessary when the data source reached its end, playback is finishing, and
+ *	 there is a delay of N frames at the beginning.
+ *	 After this call, continue calling imx_vpu_dec_decode() to retrieve the pending
+ *	 decoded frames, but the data and the codec data pointers of encoded_framt must be NULL.
+ *	 As in step 10, if IMX_VPU_DEC_OUTPUT_CODE_EOS is set, or if imx_vpu_dec_decode() returns
+ *	 a value other than IMX_VPU_DEC_RETURN_CODE_OK, stop playback and close the decoder.
  * 13. After playback is finished, close the decoder with imx_vpu_dec_close().
  * 14. Deallocate framebuffer memory blocks and the bitstream buffer memory block.
  *
@@ -655,10 +655,10 @@ char const *imx_vpu_frame_type_string(ImxVpuFrameType frame_type);
  *   mutex_lock(&mutex);
  *
  *   while (dec_initialized && !imx_vpu_dec_check_if_can_decode(decode) && !abort_waiting)
- *     condition_wait(&condition_variable, &mutex);
+ *	 condition_wait(&condition_variable, &mutex);
  *
  *   if (!abort_waiting)
- *     imx_vpu_dec_decode(decoder, encoded_frame, &output_code);
+ *	 imx_vpu_dec_decode(decoder, encoded_frame, &output_code);
  *   ...
  *
  *   mutex_unlock(&mutex);
@@ -749,30 +749,30 @@ typedef enum
 	 * fslwrapper backend; however, with the vpulib backend, it will
 	 * always use the input unless an error occurs or EOS is signaled
 	 * in drain mode. */
-	IMX_VPU_DEC_OUTPUT_CODE_INPUT_USED                   = (1UL << 0),
+	IMX_VPU_DEC_OUTPUT_CODE_INPUT_USED				   = (1UL << 0),
 	/* EOS was reached; no more unfinished frames are queued internally.
 	 * This can be reached either by bitstreams with no frame delay,
 	 * or by running the decoder in drain mode (enabled by calling
 	 * imx_vpu_dec_enable_drain_mode() ).
 	 */
-	IMX_VPU_DEC_OUTPUT_CODE_EOS                          = (1UL << 1),
+	IMX_VPU_DEC_OUTPUT_CODE_EOS						  = (1UL << 1),
 	/* A fully decoded frame is now available, and can be retrieved
 	 * by calling imx_vpu_dec_get_decoded_frame(). */
-	IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE      = (1UL << 2),
+	IMX_VPU_DEC_OUTPUT_CODE_DECODED_FRAME_AVAILABLE	  = (1UL << 2),
 	/* A frame was dropped by the decoder. The dropped frame's
 	 * context, PTS, DTS values can be retrieved by calling
 	 * imx_vpu_dec_get_dropped_frame_info(). */
-	IMX_VPU_DEC_OUTPUT_CODE_DROPPED                      = (1UL << 3),
+	IMX_VPU_DEC_OUTPUT_CODE_DROPPED					  = (1UL << 3),
 	/* There aren't enough free framebuffers available for decoding.
 	 * This usually happens when imx_vpu_dec_mark_framebuffer_as_displayed()
 	 * wasn't called before imx_vpu_dec_decode(), which can occur in
 	 * multithreaded environments. imx_vpu_dec_check_if_can_decode() is useful
 	 * to avoid this. Also see the guide above for more. */
-	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_OUTPUT_FRAMES     = (1UL << 4),
+	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_OUTPUT_FRAMES	 = (1UL << 4),
 	/* Input data for a frame is incomplete. No decoded frame will
 	 * be available until the input frame's data has been fully and
 	 * correctly delivered. */
-	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_INPUT_DATA        = (1UL << 5),
+	IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_INPUT_DATA		= (1UL << 5),
 	/* The VPU detected a change in the video sequence parameters
 	 * (like frame width and height). Decoding cannot continue. See the
 	 * explanation in the step-by-step guide above for what steps to take
@@ -781,7 +781,7 @@ typedef enum
 	 * that this flag is set immediately when input data with param changes
 	 * is fed to the decoder, even if this is for example a h.264 high
 	 * profile stream with lots of frame reordering and frame delays. */
-	IMX_VPU_DEC_OUTPUT_CODE_VIDEO_PARAMS_CHANGED         = (1UL << 6)
+	IMX_VPU_DEC_OUTPUT_CODE_VIDEO_PARAMS_CHANGED		 = (1UL << 6)
 }
 ImxVpuDecOutputCodes;
 
@@ -989,9 +989,9 @@ ImxVpuDecReturnCodes imx_vpu_dec_mark_framebuffer_as_displayed(ImxVpuDecoder *de
  *
  * Typically, loading/unloading is done in two ways:
  * (1) imx_vpu_enc_load() gets called in the startup phase of the process, and
- *     imx_vpu_enc_unload() in the shutdown phase.
+ *	 imx_vpu_enc_unload() in the shutdown phase.
  * (2) imx_vpu_enc_load() gets called every time before a encoder is to be created,
- *     and imx_vpu_enc_unload() every time after a encoder was shut down.
+ *	 and imx_vpu_enc_unload() every time after a encoder was shut down.
  *
  * Both methods are fine; however, for (2), it is important to keep in mind that
  * the imx_vpu_enc_load() / imx_vpu_enc_unload() functions are *not* thread safe,
@@ -999,69 +999,69 @@ ImxVpuDecReturnCodes imx_vpu_dec_mark_framebuffer_as_displayed(ImxVpuDecoder *de
  *
  * How to create, use, and shutdown an encoder:
  * 1. Call imx_vpu_enc_get_bitstream_buffer_info(), and allocate a DMA buffer
- *    with the given size and alignment. This is the minimum required size.
- *    The buffer can be larger, but must not be smaller than the given size.
+ *	with the given size and alignment. This is the minimum required size.
+ *	The buffer can be larger, but must not be smaller than the given size.
  * 2. Fill an instance of ImxVpuEncOpenParams with the values specific to the
- *    input data. Check the documentation of ImxVpuEncOpenParams for details
- *    about its fields. It is recommended to set default values by calling
- *    imx_vpu_enc_set_default_open_params() and afterwards set any explicit valus.
+ *	input data. Check the documentation of ImxVpuEncOpenParams for details
+ *	about its fields. It is recommended to set default values by calling
+ *	imx_vpu_enc_set_default_open_params() and afterwards set any explicit valus.
  * 3. Call imx_vpu_enc_open(), passing in a pointer to the filled ImxVpuEncOpenParams
- *    instance, and the DMA buffer of the bitstream DMA buffer which was allocated in
- *    step 1.
+ *	instance, and the DMA buffer of the bitstream DMA buffer which was allocated in
+ *	step 1.
  * 4. Call imx_vpu_enc_get_initial_info(). The encoder's initial info contains the
- *    minimum number of framebuffers that must be allocated and registered, and the
- *    address alignment that must be used when allocating DMA memory  for these
- *    framebuffers.
+ *	minimum number of framebuffers that must be allocated and registered, and the
+ *	address alignment that must be used when allocating DMA memory  for these
+ *	framebuffers.
  * 5. (Optional) Perform the necessary size and alignment calculations by calling
- *    imx_vpu_calc_framebuffer_sizes(). Pass in the width & height of the frames that
- *    shall be encoded. (The width & height do not have to be aligned; the function
- *    does this automatically.)
+ *	imx_vpu_calc_framebuffer_sizes(). Pass in the width & height of the frames that
+ *	shall be encoded. (The width & height do not have to be aligned; the function
+ *	does this automatically.)
  * 6. Create an array of at least as many ImxVpuFramebuffer instances as specified in
- *    min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
- *    enough to hold a frame. If step 5 was performed, allocating as many bytes as indicated
- *    by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each ImxVpuFramebuffer
- *    instance are valid. Using the imx_vpu_fill_framebuffer_params() convenience function
- *    for this is recommended. Note that these framebuffers are used for temporary internal
- *    encoding only, and will not contain input or output data.
+ *	min_num_required_framebuffers. Each instance must point to a DMA buffer that is big
+ *	enough to hold a frame. If step 5 was performed, allocating as many bytes as indicated
+ *	by total_size is enough. Make sure the Y,Cb,Cr,MvCol offsets in each ImxVpuFramebuffer
+ *	instance are valid. Using the imx_vpu_fill_framebuffer_params() convenience function
+ *	for this is recommended. Note that these framebuffers are used for temporary internal
+ *	encoding only, and will not contain input or output data.
  * 7. Call imx_vpu_enc_register_framebuffers() and pass in the ImxVpuFramebuffer array
- *    and the number of ImxVpuFramebuffer instances allocated in step 6.
+ *	and the number of ImxVpuFramebuffer instances allocated in step 6.
  * 8. (Optional) allocate a DMA buffer for the input frames. Only one buffer is necessary.
- *    Simply reuse the sizes used for the temporary buffers in step 7. If the incoming data
- *    is already stored in DMA buffers, this step can be omitted, since the encoder can then
- *    read the data directly.
+ *	Simply reuse the sizes used for the temporary buffers in step 7. If the incoming data
+ *	is already stored in DMA buffers, this step can be omitted, since the encoder can then
+ *	read the data directly.
  * 9. Create an instance of ImxVpuRawFrame, set its values to zero (typically by using memset()).
  * 10. Create an instance of ImxVpuEncodedFrame. Set its values to zero (typically by using memset()).
  * 11. Set the framebuffer pointer of the ImxVpuRawFrame's instance from step 9 to refer to the
- *     input DMA buffer (either the one allocated in step 8, or the one containing the input data if
- *     it already comes in DMA memory).
+ *	 input DMA buffer (either the one allocated in step 8, or the one containing the input data if
+ *	 it already comes in DMA memory).
  * 12. Fill an instance of ImxVpuEncParams with valid values. It is recommended to first set its
- *     values to zero by using memset() and then call imx_vpu_enc_set_default_encoding_params()
- *     to set default values. It is essential to make sure the acquire_output_buffer() and
- *     finish_output_buffer() function pointers are set, as these are used for acquiring buffers
- *     to write encoded output data into.
+ *	 values to zero by using memset() and then call imx_vpu_enc_set_default_encoding_params()
+ *	 to set default values. It is essential to make sure the acquire_output_buffer() and
+ *	 finish_output_buffer() function pointers are set, as these are used for acquiring buffers
+ *	 to write encoded output data into.
  * 13. If step 8 was performed, and therefore input data does *not* come in DMA memory, copy the
- *     pixels from the raw input frames into the DMA buffer allocated in step 8. Otherwise, if
- *     the raw input frames are already stored in DMA memory, this step can be omitted.
+ *	 pixels from the raw input frames into the DMA buffer allocated in step 8. Otherwise, if
+ *	 the raw input frames are already stored in DMA memory, this step can be omitted.
  * 14. Call imx_vpu_enc_encode(). Pass the raw frame, the encoded frame, and the encoding param
- *     strucutres from steps 9, 10, and 12 to it.
- *     This function will encode data, and acquire an output buffer to write the encoded data into
- *     by using the acquire_output_buffer() function pointer set in step 12. Once it is done
- *     encoding, it will call the finish_output_buffer() function from step 12. Any handle created
- *     by acquire_output_buffer() will be copied over to the encoded data frame structure. When
- *     imx_vpu_enc_encode() exits, this handle can then be used to further process the output data.
- *     It is guaranteed that once acquire_output_buffer() was called, finish_output_buffer() will
- *     be called, even if an error occurred.
- *     The IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE output code bit will always be set
- *     unless the function returned a code other than IMX_VPU_ENC_RETURN_CODE_OK.
- *     If the IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER bit is set, then header data has been
- *     written in the output memory block allocated in step 10. It is placed right before the
- *     actual encoded frame data. imx_vpu_enc_encode() will pass over the combined size of the header
- *     and the encoded frame data to acquire_output_buffer() in this case, ensuring that the output
- *     buffers are big enough.
+ *	 strucutres from steps 9, 10, and 12 to it.
+ *	 This function will encode data, and acquire an output buffer to write the encoded data into
+ *	 by using the acquire_output_buffer() function pointer set in step 12. Once it is done
+ *	 encoding, it will call the finish_output_buffer() function from step 12. Any handle created
+ *	 by acquire_output_buffer() will be copied over to the encoded data frame structure. When
+ *	 imx_vpu_enc_encode() exits, this handle can then be used to further process the output data.
+ *	 It is guaranteed that once acquire_output_buffer() was called, finish_output_buffer() will
+ *	 be called, even if an error occurred.
+ *	 The IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE output code bit will always be set
+ *	 unless the function returned a code other than IMX_VPU_ENC_RETURN_CODE_OK.
+ *	 If the IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER bit is set, then header data has been
+ *	 written in the output memory block allocated in step 10. It is placed right before the
+ *	 actual encoded frame data. imx_vpu_enc_encode() will pass over the combined size of the header
+ *	 and the encoded frame data to acquire_output_buffer() in this case, ensuring that the output
+ *	 buffers are big enough.
  * 15. Repeat steps 11 to 14 until there are no more frames to encode or an error occurs.
  * 16. After encoding is finished, close the encoder with imx_vpu_enc_close().
  * 17. Deallocate framebuffer memory blocks, the input DMA buffer block, the output memory block,
- *     and the bitstream buffer memory block.
+ *	 and the bitstream buffer memory block.
  *
  * Note that the encoder does not use any kind of frame reordering. h.264 data uses the
  * baseline profile. An input frame immediately results in an output frame (unless an error occured).
@@ -1116,15 +1116,15 @@ typedef enum
 	 * should be loaded. If this code is not present, then the encoder
 	 * didn't use it yet, so give it to the encoder again until this
 	 * code is set or an error is returned. */
-	IMX_VPU_ENC_OUTPUT_CODE_INPUT_USED                 = (1UL << 0),
+	IMX_VPU_ENC_OUTPUT_CODE_INPUT_USED				 = (1UL << 0),
 	/* A fully encoded frame is now available. The encoded_frame argument
 	 * passed to imx_vpu_enc_encode() contains information about this frame. */
-	IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE    = (1UL << 1),
+	IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE	= (1UL << 1),
 	/* The data in the encoded frame also contains header information
 	 * like SPS/PSS for h.264. Headers are always placed at the beginning
 	 * of the encoded data, and this code is never present if the
 	 * IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE isn't set. */
-	IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER            = (1UL << 2)
+	IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER			= (1UL << 2)
 }
 ImxVpuEncOutputCodes;
 
@@ -1392,15 +1392,15 @@ typedef struct
 	 * See the ImxVpuColorFormat documentation for the consequences of this. */
 	int chroma_interleave;
 
-    /* If this is 1 then the ImxVpuOutputDataWrite must be used so that
-     * the output data can be passed to the user in streaming mode before the
-     * entire frame encoding is complete.
-     * This is good when streaming the data over a network or similar medium.
-     * In this mode headers are written to the stream before the encoder finished.
-     * This may cause wrong headers in stream if the encoder failed.
-     * See ImxVpuEncParams for more details on ImxVpuOutputDataWrite
-     * The default for this value is 0 (This is mapped to the VPUs ring buffer mode)
-     */
+	/* If this is 1 then the ImxVpuOutputDataWrite must be used so that
+	 * the output data can be passed to the user in streaming mode before the
+	 * entire frame encoding is complete.
+	 * This is good when streaming the data over a network or similar medium.
+	 * In this mode headers are written to the stream before the encoder finished.
+	 * This may cause wrong headers in stream if the encoder failed.
+	 * See ImxVpuEncParams for more details on ImxVpuOutputDataWrite
+	 * The default for this value is 0 (This is mapped to the VPUs ring buffer mode)
+	 */
 	int streaming_mode;
 }
 ImxVpuEncOpenParams;

--- a/imxvpuapi/imxvpuapi.h
+++ b/imxvpuapi/imxvpuapi.h
@@ -1391,6 +1391,17 @@ typedef struct
 	 * plane, otherwise they are separated in their own planes.
 	 * See the ImxVpuColorFormat documentation for the consequences of this. */
 	int chroma_interleave;
+
+    /* If this is 1 then the ImxVpuOutputDataWrite must be used so that
+     * the output data can be passed to the user in streaming mode before the
+     * entire frame encoding is complete.
+     * This is good when streaming the data over a network or similar medium.
+     * In this mode headers are written to the stream before the encoder finished.
+     * This may cause wrong headers in stream if the encoder failed.
+     * See ImxVpuEncParams for more details on ImxVpuOutputDataWrite
+     * The default for this value is 0 (This is mapped to the VPUs ring buffer mode)
+     */
+	int streaming_mode;
 }
 ImxVpuEncOpenParams;
 

--- a/imxvpuapi/imxvpuapi.h
+++ b/imxvpuapi/imxvpuapi.h
@@ -400,7 +400,7 @@ typedef struct
 {
 	/* Stride of the Y and of the Cb&Cr components.
 	 * Specified in bytes. */
-	unsigned int y_stride, cbcr_stride;
+	unsigned int y_stride, cbcr_stride, total_size;
 
 	/* DMA buffer which contains the pixels. */
 	ImxVpuDMABuffer *dma_buffer;
@@ -1431,6 +1431,10 @@ typedef void* (*ImxVpuEncAcquireOutputBuffer)(void *context, size_t size, void *
  * ImxVpuEncParams. acquired_handle equals the value of *acquired_handle in
  * ImxVpuEncAcquireOutputBuffer. */
 typedef void (*ImxVpuEncFinishOutputBuffer)(void *context, void *acquired_handle);
+/* Function pointer used during encoding for passing the output encoded data to the user
+ * If this function is not NULL it is used instead of ImxVpuEncAcquireOutputBuffer.
+ * Also ImxVpuEncFinishOutputBuffer will not be called */
+typedef int32_t (*ImxVpuOutputDataWrite)(void *context, uint8_t const *data, uint32_t dataSize, uint64_t pts, uint64_t dts);
 
 
 typedef struct
@@ -1456,6 +1460,15 @@ typedef struct
 	 * documentation for how they are used. */
 	ImxVpuEncAcquireOutputBuffer acquire_output_buffer;
 	ImxVpuEncFinishOutputBuffer finish_output_buffer;
+
+	/* Function for directly passing the output data to the user
+	 * without copying it first.
+	 * Using this function will inhibit calls to acquire_output_buffer & finish_output_buffer.
+	 * Please note that if this function is NULL then acquire_output_buffer & finish_output_buffer must be set.
+	 */
+	ImxVpuOutputDataWrite write_output_buffer;
+
+	/* User supplied value that will be passed to the functions */
 	void *output_buffer_context;
 
 	/* Quantization parameter. Its value and valid range depends on

--- a/imxvpuapi/imxvpuapi.h
+++ b/imxvpuapi/imxvpuapi.h
@@ -80,7 +80,6 @@ typedef enum
 }
 ImxVpuMappingFlags;
 
-
 typedef struct _ImxVpuDMABuffer ImxVpuDMABuffer;
 typedef struct _ImxVpuWrappedDMABuffer ImxVpuWrappedDMABuffer;
 typedef struct _ImxVpuDMABufferAllocator ImxVpuDMABufferAllocator;
@@ -394,6 +393,21 @@ typedef enum
 }
 ImxVpuColorFormat;
 
+typedef enum
+{
+    IMX_VPU_ROTATE_0 = 0,
+    IMX_VPU_ROTATE_90 = 90,
+    IMX_VPU_ROTATE_180 = 180,
+    IMX_VPU_ROTATE_270 = 270
+}ImxVpuRotateFlags;
+
+typedef enum
+{
+    IMX_VPU_MIRROR_NONE = 0,
+    IMX_VPU_MIRROR_VER,
+    IMX_VPU_MIRROR_HOR,
+    IMX_VPU_MIRROR_HOR_VER
+}ImxVpuMirrorFlags;
 
 /* Framebuffers are frame containers, and are used both for en- and decoding. */
 typedef struct
@@ -1290,6 +1304,12 @@ typedef struct
 	/* Format encoded data to produce. */
 	ImxVpuCodecFormat codec_format;
 
+	/* This can control the rotation of the frame while encoding.
+	 * Unfortunately this value must be set before encoding actually starts
+	 * so we pass it here in the open params
+	 */
+	ImxVpuRotateFlags rotate_flags;
+
 	/* Width and height of the incoming frames, in pixels. These
 	 * do not have to be aligned to any boundaries. */
 	unsigned int frame_width, frame_height;
@@ -1464,6 +1484,9 @@ typedef struct
 	 * control is disabled (= if the bitrate value is nonzero in
 	 * ImxVpuEncOpenParams). Default value is 0. */
 	int enable_autoskip;
+
+    /* Set the mirroring for the frame. */
+	ImxVpuMirrorFlags mirrorFlags;
 
 	/* Functions for acquiring and finishing output buffers. See the
 	 * typedef documentations above for details about how these

--- a/imxvpuapi/imxvpuapi_vpulib.c
+++ b/imxvpuapi/imxvpuapi_vpulib.c
@@ -87,8 +87,8 @@
 
 #define VC1_NAL_FRAME_LAYER_MAX_SIZE   4
 
-#define VPU_WAIT_TIMEOUT             500 /* milliseconds to wait for frame completion */
-#define VPU_MAX_TIMEOUT_COUNTS       4   /* how many timeouts are allowed in series */
+#define VPU_WAIT_TIMEOUT             8 /* milliseconds to wait for frame completion */
+#define VPU_MAX_TIMEOUT_COUNTS       128   /* how many timeouts are allowed in series */
 
 #define MJPEG_ENC_HEADER_DATA_MAX_SIZE  2048
 
@@ -2410,12 +2410,15 @@ struct _ImxVpuEncoder
 	unsigned int frame_width, frame_height;
 	unsigned int frame_rate_numerator, frame_rate_denominator;
 	unsigned int aud_enable;
+	unsigned int gop_size;
+	unsigned int gop_monitor;
 
 	unsigned int num_framebuffers;
 	FrameBuffer *internal_framebuffers;
 	ImxVpuFramebuffer *framebuffers;
 
 	BOOL first_frame;
+	BOOL ring_buffer_mode;
 
 	union
 	{
@@ -2443,6 +2446,13 @@ struct _ImxVpuEncoder
 	}
 	headers;
 };
+
+struct _ImxWriteParams
+{
+    uint8_t *write_ptr, *write_ptr_start, *write_ptr_end;
+    size_t mjpeg_header_size;
+};
+
 
 
 #define IMX_VPU_ENC_HANDLE_ERROR(MSG_START, RET_CODE) \
@@ -2775,6 +2785,115 @@ char const * imx_vpu_enc_error_string(ImxVpuEncReturnCodes code)
 }
 
 
+
+
+static int
+imx_vpu_enc_readbs_ring_buffer(ImxVpuEncoder *encoder, ImxVpuEncParams *encoding_params, ImxVpuRawFrame const *raw_frame)
+{
+    RetCode ret;
+    int space = 0, room;
+    PhysicalAddress pa_read_ptr, pa_write_ptr;
+    uint8_t *target_addr;
+    uint8_t *bs_va_endaddr;
+    uint32_t size;
+
+    bs_va_endaddr = encoder->bitstream_buffer_virtual_address + VPU_ENC_MAIN_BITSTREAM_BUFFER_SIZE;
+
+    ret = vpu_EncGetBitstreamBuffer(encoder->handle, &pa_read_ptr, &pa_write_ptr,
+                    (Uint32 *)&size);
+    if (ret != RETCODE_SUCCESS) {
+        IMX_VPU_ERROR("EncGetBitstreamBuffer failed");
+        return -1;
+    }
+
+    /* No space in ring buffer */
+    if (size <= 0)
+        return 0;
+
+    space = size;
+
+    target_addr = encoder->bitstream_buffer_virtual_address + (pa_read_ptr - encoder->bitstream_buffer_physical_address);
+    if ( (target_addr + space) > bs_va_endaddr) {
+        room = bs_va_endaddr - target_addr;
+        encoding_params->write_output_buffer(encoding_params->output_buffer_context, target_addr, room, raw_frame->pts, raw_frame->dts);
+        encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->bitstream_buffer_virtual_address, (space - room), raw_frame->pts, raw_frame->dts);
+    } else {
+        encoding_params->write_output_buffer(encoding_params->output_buffer_context, target_addr, space, raw_frame->pts, raw_frame->dts);
+    }
+
+    ret = vpu_EncUpdateBitstreamBuffer(encoder->handle, space);
+    if (ret != RETCODE_SUCCESS) {
+        IMX_VPU_ERROR("EncUpdateBitstreamBuffer failed");
+        return -1;
+    }
+
+    return space;
+}
+
+static void imx_vpu_enc_write_header_data(ImxVpuEncoder *encoder, ImxVpuRawFrame const *raw_frame, ImxVpuEncParams *encoding_params, struct _ImxWriteParams *write_params, unsigned int *output_code)
+{
+
+#define ADD_HEADER_DATA(HEADER_FIELD, DESCRIPTION) \
+        do \
+        { \
+            size_t size = encoder->headers.HEADER_FIELD ## _size; \
+            if(NULL == encoding_params->write_output_buffer) \
+            { \
+                memcpy(write_params->write_ptr, encoder->headers.HEADER_FIELD, size); \
+                write_params->write_ptr += size; \
+            } \
+            else \
+            { \
+                encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.HEADER_FIELD, size, raw_frame->pts, raw_frame->dts); \
+            } \
+            IMX_VPU_LOG("added %s with %zu byte", (DESCRIPTION), size); \
+        } \
+        while (0)
+
+    switch (encoder->codec_format)
+    {
+        case IMX_VPU_CODEC_FORMAT_H264:
+        {
+            ADD_HEADER_DATA(h264_headers.sps_rbsp, "h.264 SPS RBSP");
+            ADD_HEADER_DATA(h264_headers.pps_rbsp, "h.264 PPS RBSP");
+            break;
+        }
+
+        case IMX_VPU_CODEC_FORMAT_MPEG4:
+        {
+            ADD_HEADER_DATA(mpeg4_headers.vos_header, "MPEG-4 VOS header");
+            ADD_HEADER_DATA(mpeg4_headers.vis_header, "MPEG-4 VIS header");
+            ADD_HEADER_DATA(mpeg4_headers.vol_header, "MPEG-4 VOL header");
+            break;
+        }
+
+        case IMX_VPU_CODEC_FORMAT_MJPEG:
+        {
+            if(NULL == encoding_params->write_output_buffer)
+            {
+                memcpy(write_params->write_ptr, encoder->headers.mjpeg_header_data, write_params->mjpeg_header_size);
+                write_params->write_ptr +=write_params->mjpeg_header_size;
+            }
+            else
+            {
+                encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.mjpeg_header_data, write_params->mjpeg_header_size, raw_frame->pts, raw_frame->dts);
+            }
+            IMX_VPU_LOG("added JPEG header with %zu byte", write_params->mjpeg_header_size);
+            break;
+        }
+
+        default:
+            break;
+    }
+
+    *output_code |= IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER;
+#undef ADD_HEADER_DATA
+
+}
+
+
+
+
 ImxVpuEncReturnCodes imx_vpu_enc_load(void)
 {
 	return imx_vpu_load() ? IMX_VPU_ENC_RETURN_CODE_OK : IMX_VPU_ENC_RETURN_CODE_ERROR;
@@ -2828,6 +2947,7 @@ void imx_vpu_enc_set_default_open_params(ImxVpuCodecFormat codec_format, ImxVpuE
 	open_params->use_me_zero_pmv = 0;
 	open_params->additional_intra_cost_weight = 0;
 	open_params->chroma_interleave = 0;
+	open_params->streaming_mode = 0;
 
 	switch (codec_format)
 	{
@@ -2930,6 +3050,9 @@ ImxVpuEncReturnCodes imx_vpu_enc_open(ImxVpuEncoder **encoder, ImxVpuEncOpenPara
 	enc_open_param.IntraCostWeight = open_params->additional_intra_cost_weight;
 	enc_open_param.chromaInterleave = open_params->chroma_interleave;
 
+	/* Store the gop size. This value will be used to calculate whether headers should be inserted in ring buffer mode */
+	(*encoder)->gop_size = open_params->gop_size;
+
 	/* The specification states that both values must be set if user defined
 	 * values are used, so disable both if both values are -1, and enable
 	 * both otherwise */
@@ -2956,9 +3079,9 @@ ImxVpuEncReturnCodes imx_vpu_enc_open(ImxVpuEncoder **encoder, ImxVpuEncOpenPara
 	/* The i.MX6 does not support dynamic allocation */
 	enc_open_param.dynamicAllocEnable = 0;
 
-	/* Ring buffer mode isn't needed, so disable it, instructing
-	 * the VPU to use the line buffer mode instead */
-	enc_open_param.ringBufferEnable = 0;
+	/* Ring buffer mode  */
+	enc_open_param.ringBufferEnable = open_params->streaming_mode;
+	(*encoder)->ring_buffer_mode = (BOOL)open_params->streaming_mode;
 
 	/* Currently, no tiling is supported */
 	enc_open_param.linear2TiledEnable = 1;
@@ -3454,23 +3577,36 @@ void imx_vpu_enc_configure_intra_qp(ImxVpuEncoder *encoder, int intra_qp)
 	vpu_EncGiveCommand(encoder->handle, ENC_SET_INTRA_QP, &intra_qp);
 }
 
-
 ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame const *raw_frame, ImxVpuEncodedFrame *encoded_frame, ImxVpuEncParams *encoding_params, unsigned int *output_code)
 {
 #define GET_BITSTREAM_VIRT_ADDR(BITSTREAM_PHYS_ADDR) (encoder->bitstream_buffer_virtual_address + ((BITSTREAM_PHYS_ADDR) - encoder->bitstream_buffer_physical_address))
 
-	ImxVpuEncReturnCodes ret;
+#define WRITE_AUD() \
+    do{ \
+        if(NULL == encoding_params->write_output_buffer) \
+        { \
+            memcpy(write_params.write_ptr, h264_aud, sizeof(h264_aud)); \
+            write_params.write_ptr += sizeof(h264_aud); \
+        } \
+        else \
+        { \
+            encoding_params->write_output_buffer(encoding_params->output_buffer_context, h264_aud, sizeof(h264_aud), raw_frame->pts, raw_frame->dts); \
+        } \
+    }while(0)
+
+
+    uint8_t const h264_aud[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0xF0 };
+
+    ImxVpuEncReturnCodes ret;
 	RetCode enc_ret;
 	EncParam enc_param;
 	EncOutputInfo enc_output_info;
 	FrameBuffer source_framebuffer;
 	imx_vpu_phys_addr_t raw_frame_phys_addr;
-	uint8_t *write_ptr, *write_ptr_start = NULL, *write_ptr_end;
 	BOOL timeout;
 	BOOL add_header;
-	size_t mjpeg_header_size = 0;
 	size_t encoded_data_size;
-	uint8_t const h264_aud[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0xF0 };
+	struct _ImxWriteParams write_params;
 
 	ret = IMX_VPU_ENC_RETURN_CODE_OK;
 
@@ -3480,9 +3616,10 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 	assert(output_code != NULL);
 	assert(encoding_params->write_output_buffer != NULL || encoding_params->acquire_output_buffer != NULL);
 	assert(encoding_params->write_output_buffer != NULL || encoding_params->finish_output_buffer != NULL);
+	assert(encoding_params->write_output_buffer != NULL || encoder->ring_buffer_mode == FALSE);
 
 	*output_code = 0;
-	write_ptr_start = NULL;
+	memset(&write_params, 0, sizeof(write_params));
 
 	/* Set this here to ensure that the handle is NULL if an error occurs
 	 * before acquire_output_buffer() is called */
@@ -3504,7 +3641,7 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 		vpu_EncGiveCommand(encoder->handle, ENC_GET_JPEG_HEADER, &mjpeg_param);
 		IMX_VPU_LOG("added JPEG header with %d byte", mjpeg_param.size);
 
-		mjpeg_header_size = mjpeg_param.size;
+		write_params.mjpeg_header_size = mjpeg_param.size;
 
 		*output_code |= IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER;
 	}
@@ -3550,6 +3687,40 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 	if (ret != IMX_VPU_ENC_RETURN_CODE_OK)
 		goto finish;
 
+	if(encoder->ring_buffer_mode)
+	{
+	    /* We are in streaming mode - The header should be written before the frame is complete or any part of it for that matter */
+	    /* Check to see if an header should be added to the output */
+	    switch (encoder->codec_format)
+	    {
+	        case IMX_VPU_CODEC_FORMAT_MJPEG:
+	        {
+	            add_header = TRUE;
+	            break;
+	        }
+
+	        case IMX_VPU_CODEC_FORMAT_H264:
+	        case IMX_VPU_CODEC_FORMAT_MPEG4:
+	            add_header = encoder->first_frame || encoding_params->force_I_frame || encoder->gop_monitor == 0;
+	            break;
+
+	        default:
+	            add_header = FALSE;
+	    }
+
+	    /* AUD should come before SPS/PPS - see the code in
+         * imx_vpu_enc_open() for details */
+	    if(encoder->aud_enable)
+	    {
+	        WRITE_AUD();
+	        IMX_VPU_LOG("added h.264 AUD");
+	    }
+	    if(add_header)
+	    {
+	        imx_vpu_enc_write_header_data(encoder, raw_frame, encoding_params, &write_params, output_code);
+	    }
+	}
+
 	/* Wait for frame completion */
 	{
 		int cnt;
@@ -3563,12 +3734,25 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 		{
 			if (vpu_WaitForInt(VPU_WAIT_TIMEOUT) != RETCODE_SUCCESS)
 			{
-				IMX_VPU_INFO("timeout after waiting %d ms for frame completion", VPU_WAIT_TIMEOUT);
+			    if(encoder->ring_buffer_mode)
+			    {
+			        if(0 > imx_vpu_enc_readbs_ring_buffer(encoder, encoding_params, raw_frame))
+			        {
+			            IMX_VPU_ERROR("Unable to read ring buffer");
+			            timeout = false;
+			            break;
+			        }
+			    }
+			    usleep(VPU_WAIT_TIMEOUT*1000);
 			}
 			else
 			{
 				timeout = FALSE;
 				break;
+			}
+			if(cnt > 0 && 0 == (cnt & 63))
+			{
+                IMX_VPU_INFO("timeout after waiting %d ms for frame completion", VPU_WAIT_TIMEOUT*64);
 			}
 		}
 	}
@@ -3613,173 +3797,127 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 		enc_output_info.numOfSlices
 	);
 
-
-	switch (encoder->codec_format)
+	if(encoder->ring_buffer_mode)
 	{
-		case IMX_VPU_CODEC_FORMAT_MJPEG:
-		{
-			add_header = TRUE;
-			break;
-		}
-
-		case IMX_VPU_CODEC_FORMAT_H264:
-		case IMX_VPU_CODEC_FORMAT_MPEG4:
-			add_header = encoder->first_frame || encoding_params->force_I_frame || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_IDR) || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_I);
-			break;
-
-		default:
-			add_header = FALSE;
-	}
-
-	encoded_data_size = enc_output_info.bitstreamSize;
-	if (encoder->aud_enable)
-		encoded_data_size += sizeof(h264_aud);
-
-	if (add_header)
-	{
-		switch (encoder->codec_format)
-		{
-			case IMX_VPU_CODEC_FORMAT_MJPEG:
-				encoded_data_size += mjpeg_header_size;
-				break;
-
-			case IMX_VPU_CODEC_FORMAT_H264:
-				encoded_data_size += encoder->headers.h264_headers.sps_rbsp_size + encoder->headers.h264_headers.pps_rbsp_size;
-				break;
-
-			case IMX_VPU_CODEC_FORMAT_MPEG4:
-				encoded_data_size += encoder->headers.mpeg4_headers.vos_header_size + encoder->headers.mpeg4_headers.vis_header_size + encoder->headers.mpeg4_headers.vol_header_size;
-				break;
-
-			default:
-				break;
-		}
-	}
-
-	encoded_frame->data_size = encoded_data_size;
-	if(NULL == encoding_params->write_output_buffer)
-	{
-        write_ptr_start = encoding_params->acquire_output_buffer(encoding_params->output_buffer_context, encoded_data_size, &(encoded_frame->acquired_handle));
-        if (write_ptr_start == NULL)
+        if(0 <= imx_vpu_enc_readbs_ring_buffer(encoder, encoding_params, raw_frame))
         {
-            IMX_VPU_ERROR("could not acquire buffer with %zu byte for encoded frame data", encoded_data_size);
-            ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
-            goto finish;
+            *output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
+        }
+	}
+	else
+	{
+	    /* Check to see if an header should be added to the output */
+	    switch (encoder->codec_format)
+	    {
+	        case IMX_VPU_CODEC_FORMAT_MJPEG:
+	        {
+	            add_header = TRUE;
+	            break;
+	        }
+
+	        case IMX_VPU_CODEC_FORMAT_H264:
+	        case IMX_VPU_CODEC_FORMAT_MPEG4:
+	            add_header = encoder->first_frame || encoding_params->force_I_frame || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_IDR) || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_I);
+	            break;
+
+	        default:
+	            add_header = FALSE;
+	    }
+
+	    encoded_data_size = enc_output_info.bitstreamSize;
+        if (encoder->aud_enable)
+            encoded_data_size += sizeof(h264_aud);
+
+        if (add_header)
+        {
+            switch (encoder->codec_format)
+            {
+                case IMX_VPU_CODEC_FORMAT_MJPEG:
+                    encoded_data_size += write_params.mjpeg_header_size;
+                    break;
+
+                case IMX_VPU_CODEC_FORMAT_H264:
+                    encoded_data_size += encoder->headers.h264_headers.sps_rbsp_size + encoder->headers.h264_headers.pps_rbsp_size;
+                    break;
+
+                case IMX_VPU_CODEC_FORMAT_MPEG4:
+                    encoded_data_size += encoder->headers.mpeg4_headers.vos_header_size + encoder->headers.mpeg4_headers.vis_header_size + encoder->headers.mpeg4_headers.vol_header_size;
+                    break;
+
+                default:
+                    break;
+            }
         }
 
-        write_ptr = write_ptr_start;
-        write_ptr_end = write_ptr + encoded_data_size;
+        encoded_frame->data_size = encoded_data_size;
+        if(NULL == encoding_params->write_output_buffer)
+        {
+            write_params.write_ptr_start = encoding_params->acquire_output_buffer(encoding_params->output_buffer_context, encoded_data_size, &(encoded_frame->acquired_handle));
+            if (write_params.write_ptr_start == NULL)
+            {
+                IMX_VPU_ERROR("could not acquire buffer with %zu byte for encoded frame data", encoded_data_size);
+                ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
+                goto finish;
+            }
+
+            write_params.write_ptr = write_params.write_ptr_start;
+            write_params.write_ptr_end = write_params.write_ptr + encoded_data_size;
+        }
+
+        /* AUD should come before SPS/PPS - see the code in
+         * imx_vpu_enc_open() for details */
+        if(encoder->aud_enable)
+        {
+            WRITE_AUD();
+            IMX_VPU_LOG("added h.264 AUD");
+        }
+        if(add_header)
+        {
+            imx_vpu_enc_write_header_data(encoder, raw_frame, encoding_params, &write_params, output_code);
+        }
+        /* Get the encoded data out of the bitstream buffer into the output buffer */
+        if (enc_output_info.bitstreamBuffer != 0)
+        {
+            uint8_t const *output_data_ptr = GET_BITSTREAM_VIRT_ADDR(enc_output_info.bitstreamBuffer);
+
+            if(NULL == encoding_params->write_output_buffer)
+            {
+                ptrdiff_t available_space = write_params.write_ptr_end - write_params.write_ptr;
+
+                if (available_space < (ptrdiff_t)(enc_output_info.bitstreamSize))
+                {
+                    IMX_VPU_ERROR(
+                        "insufficient space in output buffer for encoded data: need %u byte, got %td",
+                        enc_output_info.bitstreamSize,
+                        available_space
+                    );
+                    ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
+
+                    goto finish;
+                }
+                memcpy(write_params.write_ptr, output_data_ptr, enc_output_info.bitstreamSize);
+                write_params.write_ptr += enc_output_info.bitstreamSize;
+            }
+            else
+            {
+                encoding_params->write_output_buffer(encoding_params->output_buffer_context, output_data_ptr, enc_output_info.bitstreamSize, raw_frame->pts, raw_frame->dts);
+            }
+
+            IMX_VPU_LOG("added main encoded frame data with %u byte", enc_output_info.bitstreamSize);
+            *output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
+        }
 	}
-	/* AUD should come before SPS/PPS - see the code in
-	 * imx_vpu_enc_open() for details */
-	if (encoder->aud_enable)
-	{
-	    if(NULL == encoding_params->write_output_buffer)
-	    {
-	        memcpy(write_ptr, h264_aud, sizeof(h264_aud));
-	        write_ptr += sizeof(h264_aud);
-	    }
-	    else
-	    {
-	        encoding_params->write_output_buffer(encoding_params->output_buffer_context, h264_aud, sizeof(h264_aud), raw_frame->pts, raw_frame->dts);
-	    }
-		IMX_VPU_LOG("added h.264 AUD");
-	}
-
-	if (add_header)
-	{
-#define ADD_HEADER_DATA(HEADER_FIELD, DESCRIPTION) \
-		do \
-		{ \
-			size_t size = encoder->headers.HEADER_FIELD ## _size; \
-	        if(NULL == encoding_params->write_output_buffer) \
-	        { \
-                memcpy(write_ptr, encoder->headers.HEADER_FIELD, size); \
-                write_ptr += size; \
-	        } \
-	        else \
-	        { \
-	            encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.HEADER_FIELD, size, raw_frame->pts, raw_frame->dts); \
-	        } \
-			IMX_VPU_LOG("added %s with %zu byte", (DESCRIPTION), size); \
-		} \
-		while (0)
-
-		switch (encoder->codec_format)
-		{
-			case IMX_VPU_CODEC_FORMAT_H264:
-			{
-				ADD_HEADER_DATA(h264_headers.sps_rbsp, "h.264 SPS RBSP");
-				ADD_HEADER_DATA(h264_headers.pps_rbsp, "h.264 PPS RBSP");
-				break;
-			}
-
-			case IMX_VPU_CODEC_FORMAT_MPEG4:
-			{
-				ADD_HEADER_DATA(mpeg4_headers.vos_header, "MPEG-4 VOS header");
-				ADD_HEADER_DATA(mpeg4_headers.vis_header, "MPEG-4 VIS header");
-				ADD_HEADER_DATA(mpeg4_headers.vol_header, "MPEG-4 VOL header");
-				break;
-			}
-
-			case IMX_VPU_CODEC_FORMAT_MJPEG:
-			{
-	            if(NULL == encoding_params->write_output_buffer)
-	            {
-                    memcpy(write_ptr, encoder->headers.mjpeg_header_data, mjpeg_header_size);
-                    write_ptr += mjpeg_header_size;
-	            }
-	            else
-	            {
-	                encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.mjpeg_header_data, mjpeg_header_size, raw_frame->pts, raw_frame->dts);
-	            }
-				IMX_VPU_LOG("added JPEG header with %zu byte", mjpeg_header_size);
-				break;
-			}
-
-			default:
-				break;
-		}
-
-		*output_code |= IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER;
-#undef ADD_HEADER_DATA
-	}
-
 
 	/* Add this flag since the raw frame has been successfully consumed */
 	*output_code |= IMX_VPU_ENC_OUTPUT_CODE_INPUT_USED;
 
-	/* Get the encoded data out of the bitstream buffer into the output buffer */
-	if (enc_output_info.bitstreamBuffer != 0)
-	{
-        uint8_t const *output_data_ptr = GET_BITSTREAM_VIRT_ADDR(enc_output_info.bitstreamBuffer);
+	/* Increment the gop monitor. This is necessary to correctly insert headers in ring buffer mode */
+	++encoder->gop_monitor;
+    if(encoder->gop_monitor == encoder->gop_size)
+    {
+        encoder->gop_monitor = 0;
+    }
 
-        if(NULL == encoding_params->write_output_buffer)
-        {
-            ptrdiff_t available_space = write_ptr_end - write_ptr;
-
-            if (available_space < (ptrdiff_t)(enc_output_info.bitstreamSize))
-            {
-                IMX_VPU_ERROR(
-                    "insufficient space in output buffer for encoded data: need %u byte, got %td",
-                    enc_output_info.bitstreamSize,
-                    available_space
-                );
-                ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
-
-                goto finish;
-            }
-            memcpy(write_ptr, output_data_ptr, enc_output_info.bitstreamSize);
-            write_ptr += enc_output_info.bitstreamSize;
-        }
-        else
-        {
-            encoding_params->write_output_buffer(encoding_params->output_buffer_context, output_data_ptr, enc_output_info.bitstreamSize, raw_frame->pts, raw_frame->dts);
-        }
-
-        IMX_VPU_LOG("added main encoded frame data with %u byte", enc_output_info.bitstreamSize);
-		*output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
-	}
 
 	/* Since the encoder does not perform any kind of delay
 	 * or reordering, this is appropriate, because in that
@@ -3792,10 +3930,11 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 	encoder->first_frame = FALSE;
 
 finish:
-	if (write_ptr_start != NULL)
+	if (write_params.write_ptr_start != NULL)
 		encoding_params->finish_output_buffer(encoding_params->output_buffer_context, encoded_frame->acquired_handle);
 
 	return ret;
 
 #undef GET_BITSTREAM_VIRT_ADDR
+#undef WRITE_AUD
 }

--- a/imxvpuapi/imxvpuapi_vpulib.c
+++ b/imxvpuapi/imxvpuapi_vpulib.c
@@ -60,13 +60,13 @@
 #define MIN_NUM_FREE_FB_REQUIRED 5
 #define FRAME_ALIGN 16
 
-#define VPU_MEMORY_ALIGNMENT		 0x8
+#define VPU_MEMORY_ALIGNMENT               0x8
 #define VPU_DEC_MAIN_BITSTREAM_BUFFER_SIZE (1024*1024*3)
 #define VPU_ENC_MAIN_BITSTREAM_BUFFER_SIZE (1024*1024*1)
-#define VPU_ENC_MPEG4_SCRATCH_SIZE		 0x080000
-#define VPU_MAX_SLICE_BUFFER_SIZE		  (1920*1088*15/20)
-#define VPU_PS_SAVE_BUFFER_SIZE			(1024*512)
-#define VPU_VP8_MB_PRED_BUFFER_SIZE		(68*(1920*1088/256))
+#define VPU_ENC_MPEG4_SCRATCH_SIZE         0x080000
+#define VPU_MAX_SLICE_BUFFER_SIZE          (1920*1088*15/20)
+#define VPU_PS_SAVE_BUFFER_SIZE            (1024*512)
+#define VPU_VP8_MB_PRED_BUFFER_SIZE        (68*(1920*1088/256))
 
 /* The decoder's bitstream buffer shares space with other fields,
  * to not have to allocate several DMA blocks. The actual bitstream buffer is called
@@ -77,20 +77,20 @@
 
 #define VPU_ENC_MIN_REQUIRED_BITSTREAM_BUFFER_SIZE  (VPU_ENC_MAIN_BITSTREAM_BUFFER_SIZE + VPU_ENC_MPEG4_SCRATCH_SIZE)
 
-#define VPU_ENC_NUM_EXTRA_SUBSAMPLE_FRAMEBUFFERS  2
+#define VPU_ENC_NUM_EXTRA_SUBSAMPLE_FRAMEBUFFERS    2
 
 #define VP8_SEQUENCE_HEADER_SIZE  32
-#define VP8_FRAME_HEADER_SIZE	 12
+#define VP8_FRAME_HEADER_SIZE     12
 
 #define WMV3_RCV_SEQUENCE_LAYER_SIZE (6 * 4)
-#define WMV3_RCV_FRAME_LAYER_SIZE	4
+#define WMV3_RCV_FRAME_LAYER_SIZE    4
 
 #define VC1_NAL_FRAME_LAYER_MAX_SIZE   4
 
-#define VPU_RB_WAIT_TIMEOUT			 10 /* milliseconds to wait for frame completion */
-#define VPU_RB_MAX_TIMEOUT_COUNTS	   64   /* how many timeouts are allowed in series */
-#define VPU_WAIT_TIMEOUT  (VPU_RB_WAIT_TIMEOUT*50)
-#define VPU_MAX_TIMEOUT_COUNTS 4
+#define VPU_RB_WAIT_TIMEOUT         10 /* milliseconds to wait for frame completion */
+#define VPU_RB_MAX_TIMEOUT_COUNTS   64 /* how many timeouts are allowed in series */
+#define VPU_WAIT_TIMEOUT            (VPU_RB_WAIT_TIMEOUT*50)
+#define VPU_MAX_TIMEOUT_COUNTS      4
 
 #define MJPEG_ENC_HEADER_DATA_MAX_SIZE  2048
 
@@ -450,13 +450,13 @@ ImxVpuInterlacingMode convert_interlacing_mode(ImxVpuCodecFormat codec_format, D
 typedef struct
 {
 	ImxVpuDMABuffer parent;
-	vpu_mem_desc mem_desc;
+	vpu_mem_desc    mem_desc;
 
 	/* Not the same as mem_desc->size
 	 * the value in mem_desc is potentially larger due to alignment */
 	size_t size;
 
-	uint8_t*			aligned_virtual_address;
+	uint8_t*            aligned_virtual_address;
 	imx_vpu_phys_addr_t aligned_physical_address;
 }
 DefaultDMABuffer;
@@ -667,9 +667,9 @@ void imx_vpu_calc_framebuffer_sizes(ImxVpuColorFormat color_format, unsigned int
 	 * while in the chroma_interleave == 1 case, there is one shared chroma plane
 	 * for both Cb and Cr data, with cbcr_size bytes */
 	calculated_sizes->total_size = calculated_sizes->y_size
-								 + (chroma_interleave ? calculated_sizes->cbcr_size : (calculated_sizes->cbcr_size * 2))
-								 + calculated_sizes->mvcol_size
-								 + alignment;
+                                 + (chroma_interleave ? calculated_sizes->cbcr_size : (calculated_sizes->cbcr_size * 2))
+                                 + calculated_sizes->mvcol_size
+                                 + alignment;
 
 	calculated_sizes->chroma_interleave = chroma_interleave;
 }
@@ -701,7 +701,7 @@ void imx_vpu_fill_framebuffer_params(ImxVpuFramebuffer *framebuffer, ImxVpuFrame
 
 /* Frames are not just occupied or free. They can be in one of three modes:
  * - FrameMode_Free: framebuffer is not being used for decoding, and does not hold
-	 a displayable frame
+     a displayable frame
  * - FrameMode_ReservedForDecoding: framebuffer contains frame data that is
  *   being decoded; this data can not be displayed yet though
  * - FrameMode_ContainsDisplayableFrame: framebuffer contains frame that has
@@ -778,12 +778,12 @@ struct _ImxVpuDecoder
 	imx_vpu_dec_handle_error_full(__FILE__, __LINE__, __func__, (MSG_START), (RET_CODE))
 
 
-#define VPU_DECODER_DISPLAYIDX_ALL_FRAMES_DISPLAYED -1
+#define VPU_DECODER_DISPLAYIDX_ALL_FRAMES_DISPLAYED          -1
 #define VPU_DECODER_DISPLAYIDX_SKIP_MODE_NO_FRAME_TO_DISPLAY -2
-#define VPU_DECODER_DISPLAYIDX_NO_FRAME_TO_DISPLAY -3
+#define VPU_DECODER_DISPLAYIDX_NO_FRAME_TO_DISPLAY           -3
 
 #define VPU_DECODER_DECODEIDX_ALL_FRAMES_DECODED -1
-#define VPU_DECODER_DECODEIDX_FRAME_NOT_DECODED -2
+#define VPU_DECODER_DECODEIDX_FRAME_NOT_DECODED  -2
 
 
 static ImxVpuDecReturnCodes imx_vpu_dec_handle_error_full(char const *fn, int linenr, char const *funcn, char const *msg_start, RetCode ret_code);
@@ -905,16 +905,16 @@ char const * imx_vpu_dec_error_string(ImxVpuDecReturnCodes code)
 {
 	switch (code)
 	{
-		case IMX_VPU_DEC_RETURN_CODE_OK:						return "ok";
-		case IMX_VPU_DEC_RETURN_CODE_ERROR:					 return "unspecified error";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_PARAMS:			return "invalid params";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_HANDLE:			return "invalid handle";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_FRAMEBUFFER:	   return "invalid framebuffer";
+		case IMX_VPU_DEC_RETURN_CODE_OK:                        return "ok";
+		case IMX_VPU_DEC_RETURN_CODE_ERROR:                     return "unspecified error";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_PARAMS:            return "invalid params";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_HANDLE:            return "invalid handle";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_FRAMEBUFFER:       return "invalid framebuffer";
 		case IMX_VPU_DEC_RETURN_CODE_INSUFFICIENT_FRAMEBUFFERS: return "insufficient framebuffers";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_STRIDE:			return "invalid stride";
-		case IMX_VPU_DEC_RETURN_CODE_WRONG_CALL_SEQUENCE:	   return "wrong call sequence";
-		case IMX_VPU_DEC_RETURN_CODE_TIMEOUT:				   return "timeout";
-		case IMX_VPU_DEC_RETURN_CODE_ALREADY_CALLED:			return "already called";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_STRIDE:            return "invalid stride";
+		case IMX_VPU_DEC_RETURN_CODE_WRONG_CALL_SEQUENCE:       return "wrong call sequence";
+		case IMX_VPU_DEC_RETURN_CODE_TIMEOUT:                   return "timeout";
+		case IMX_VPU_DEC_RETURN_CODE_ALREADY_CALLED:            return "already called";
 		default: return "<unknown>";
 	}
 }
@@ -1297,11 +1297,11 @@ ImxVpuDecReturnCodes imx_vpu_dec_register_framebuffers(ImxVpuDecoder *decoder, I
 	if (decoder->codec_format != IMX_VPU_CODEC_FORMAT_MJPEG)
 	{
 		dec_ret = vpu_DecRegisterFrameBuffer(
-			decoder->handle,
-			decoder->internal_framebuffers,
-			num_framebuffers,
-			framebuffers[0].y_stride, /* The stride value is assumed to be the same for all framebuffers */
-			&buf_info
+            decoder->handle,
+            decoder->internal_framebuffers,
+            num_framebuffers,
+            framebuffers[0].y_stride, /* The stride value is assumed to be the same for all framebuffers */
+            &buf_info
 		);
 		ret = IMX_VPU_DEC_HANDLE_ERROR("could not register framebuffers", dec_ret);
 		if (ret != IMX_VPU_DEC_RETURN_CODE_OK)
@@ -2103,28 +2103,28 @@ ImxVpuDecReturnCodes imx_vpu_dec_decode(ImxVpuDecoder *decoder, ImxVpuEncodedFra
 
 		/* Log some information about the decoded frame */
 		IMX_VPU_LOG(
-			"output info:  indexFrameDisplay %d  indexFrameDecoded %d  NumDecFrameBuf %d  picType %d  idrFlg %d  numOfErrMBs %d  hScaleFlag %d  vScaleFlag %d  notSufficientPsBuffer %d  notSufficientSliceBuffer %d  decodingSuccess %d  interlacedFrame %d  mp4PackedPBframe %d  h264Npf %d  pictureStructure %d  topFieldFirst %d  repeatFirstField %d  fieldSequence %d  decPicWidth %d  decPicHeight %d",
-			decoder->dec_output_info.indexFrameDisplay,
-			decoder->dec_output_info.indexFrameDecoded,
-			decoder->dec_output_info.NumDecFrameBuf,
-			decoder->dec_output_info.picType,
-			decoder->dec_output_info.idrFlg,
-			decoder->dec_output_info.numOfErrMBs,
-			decoder->dec_output_info.hScaleFlag,
-			decoder->dec_output_info.vScaleFlag,
-			decoder->dec_output_info.notSufficientPsBuffer,
-			decoder->dec_output_info.notSufficientSliceBuffer,
-			decoder->dec_output_info.decodingSuccess,
-			decoder->dec_output_info.interlacedFrame,
-			decoder->dec_output_info.mp4PackedPBframe,
-			decoder->dec_output_info.h264Npf,
-			decoder->dec_output_info.pictureStructure,
-			decoder->dec_output_info.topFieldFirst,
-			decoder->dec_output_info.repeatFirstField,
-			decoder->dec_output_info.fieldSequence,
-			decoder->dec_output_info.decPicWidth,
-			decoder->dec_output_info.decPicHeight
-		);
+            "output info:  indexFrameDisplay %d  indexFrameDecoded %d  NumDecFrameBuf %d  picType %d  idrFlg %d  numOfErrMBs %d  hScaleFlag %d  vScaleFlag %d  notSufficientPsBuffer %d  notSufficientSliceBuffer %d  decodingSuccess %d  interlacedFrame %d  mp4PackedPBframe %d  h264Npf %d  pictureStructure %d  topFieldFirst %d  repeatFirstField %d  fieldSequence %d  decPicWidth %d  decPicHeight %d",
+            decoder->dec_output_info.indexFrameDisplay,
+            decoder->dec_output_info.indexFrameDecoded,
+            decoder->dec_output_info.NumDecFrameBuf,
+            decoder->dec_output_info.picType,
+            decoder->dec_output_info.idrFlg,
+            decoder->dec_output_info.numOfErrMBs,
+            decoder->dec_output_info.hScaleFlag,
+            decoder->dec_output_info.vScaleFlag,
+            decoder->dec_output_info.notSufficientPsBuffer,
+            decoder->dec_output_info.notSufficientSliceBuffer,
+            decoder->dec_output_info.decodingSuccess,
+            decoder->dec_output_info.interlacedFrame,
+            decoder->dec_output_info.mp4PackedPBframe,
+            decoder->dec_output_info.h264Npf,
+            decoder->dec_output_info.pictureStructure,
+            decoder->dec_output_info.topFieldFirst,
+            decoder->dec_output_info.repeatFirstField,
+            decoder->dec_output_info.fieldSequence,
+            decoder->dec_output_info.decPicWidth,
+            decoder->dec_output_info.decPicHeight
+        );
 
 
 		/* VP8 requires some workarounds */
@@ -2774,15 +2774,15 @@ char const * imx_vpu_enc_error_string(ImxVpuEncReturnCodes code)
 {
 	switch (code)
 	{
-		case IMX_VPU_ENC_RETURN_CODE_OK:						return "ok";
-		case IMX_VPU_ENC_RETURN_CODE_ERROR:					 return "unspecified error";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_PARAMS:			return "invalid params";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_HANDLE:			return "invalid handle";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_FRAMEBUFFER:	   return "invalid framebuffer";
+		case IMX_VPU_ENC_RETURN_CODE_OK:                        return "ok";
+		case IMX_VPU_ENC_RETURN_CODE_ERROR:                     return "unspecified error";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_PARAMS:            return "invalid params";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_HANDLE:            return "invalid handle";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_FRAMEBUFFER:       return "invalid framebuffer";
 		case IMX_VPU_ENC_RETURN_CODE_INSUFFICIENT_FRAMEBUFFERS: return "insufficient framebuffers";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_STRIDE:			return "invalid stride";
-		case IMX_VPU_ENC_RETURN_CODE_WRONG_CALL_SEQUENCE:	   return "wrong call sequence";
-		case IMX_VPU_ENC_RETURN_CODE_TIMEOUT:				   return "timeout";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_STRIDE:            return "invalid stride";
+		case IMX_VPU_ENC_RETURN_CODE_WRONG_CALL_SEQUENCE:       return "wrong call sequence";
+		case IMX_VPU_ENC_RETURN_CODE_TIMEOUT:                   return "timeout";
 		default: return "<unknown>";
 	}
 }
@@ -2981,7 +2981,7 @@ void imx_vpu_enc_set_default_open_params(ImxVpuCodecFormat codec_format, ImxVpuE
 
 		case IMX_VPU_CODEC_FORMAT_MJPEG:
 			open_params->codec_params.mjpeg_params.quality_factor = 85;
-
+			break;
 		default:
 			break;
 	}
@@ -3038,15 +3038,15 @@ ImxVpuEncReturnCodes imx_vpu_enc_open(ImxVpuEncoder **encoder, ImxVpuEncOpenPara
 	/* Miscellaneous codec format independent values */
 	switch(open_params->rotate_flags)
 	{
-	    case IMX_VPU_ROTATE_90:
-	    case IMX_VPU_ROTATE_270:
-	        enc_open_param.picWidth = open_params->frame_height;
-	        enc_open_param.picHeight = open_params->frame_width;
-	        break;
-	    default:
-	        enc_open_param.picWidth = open_params->frame_width;
-	        enc_open_param.picHeight = open_params->frame_height;
-	        break;
+		case IMX_VPU_ROTATE_90:
+		case IMX_VPU_ROTATE_270:
+			enc_open_param.picWidth = open_params->frame_height;
+			enc_open_param.picHeight = open_params->frame_width;
+			break;
+		default:
+			enc_open_param.picWidth = open_params->frame_width;
+			enc_open_param.picHeight = open_params->frame_height;
+			break;
 	}
 	/* Fix the width & heoght to reflect rotation */
 	open_params->frame_width = enc_open_param.picWidth;
@@ -3226,8 +3226,8 @@ ImxVpuEncReturnCodes imx_vpu_enc_open(ImxVpuEncoder **encoder, ImxVpuEncOpenPara
 
 	/* Store some parameters internally for later use */
 	(*encoder)->codec_format = open_params->codec_format;
-    (*encoder)->frame_width = enc_open_param.picWidth;
-    (*encoder)->frame_height = enc_open_param.picHeight;
+	(*encoder)->frame_width = enc_open_param.picWidth;
+	(*encoder)->frame_height = enc_open_param.picHeight;
 	(*encoder)->frame_rate_numerator = open_params->frame_rate_numerator;
 	(*encoder)->frame_rate_denominator = open_params->frame_rate_denominator;
 
@@ -3410,35 +3410,35 @@ ImxVpuEncReturnCodes imx_vpu_enc_register_framebuffers(ImxVpuEncoder *encoder, I
 	}
 
 	{
-        /* the datatypes are int, but this is undocumented; determined by looking
-         * into the imx-vpu library's vpu_lib.c vpu_EncGiveCommand() definition */
-        int mirror = 0;
-        int enable_mirror = 1; /* Mirroring is enabled by default since it can be controlled online */
+		/* the datatypes are int, but this is undocumented; determined by looking
+		 * into the imx-vpu library's vpu_lib.c vpu_EncGiveCommand() definition */
+		int mirror = 0;
+		int enable_mirror = 1; /* Mirroring is enabled by default since it can be controlled online */
 
-        if(IMX_VPU_ROTATE_0 != encoder->rotate_angle)
-        {
-            int enable_rot = 1;
-            vpu_EncGiveCommand(encoder->handle, ENABLE_ROTATION, (void*)&enable_rot);
-            vpu_EncGiveCommand(encoder->handle, SET_ROTATION_ANGLE, (void *)&encoder->rotate_angle);
-        }
-        else
-        {
-            /* No need for rotation so let's disable it */
-            int enable_rot = 0;
-            vpu_EncGiveCommand(encoder->handle, ENABLE_ROTATION, (void*)&enable_rot);
-        }
-        vpu_EncGiveCommand(encoder->handle, ENABLE_MIRRORING, (void*)&enable_mirror);
-        vpu_EncGiveCommand(encoder->handle, SET_MIRROR_DIRECTION,(void *)(&mirror));
+		if(IMX_VPU_ROTATE_0 != encoder->rotate_angle)
+		{
+			int enable_rot = 1;
+			vpu_EncGiveCommand(encoder->handle, ENABLE_ROTATION, (void*)&enable_rot);
+			vpu_EncGiveCommand(encoder->handle, SET_ROTATION_ANGLE, (void *)&encoder->rotate_angle);
+		}
+		else
+		{
+			/* No need for rotation so let's disable it */
+			int enable_rot = 0;
+			vpu_EncGiveCommand(encoder->handle, ENABLE_ROTATION, (void*)&enable_rot);
+		}
+		vpu_EncGiveCommand(encoder->handle, ENABLE_MIRRORING, (void*)&enable_mirror);
+		vpu_EncGiveCommand(encoder->handle, SET_MIRROR_DIRECTION,(void *)(&mirror));
 
-        /* Set default rotator settings for motion JPEG */
-        if (encoder->codec_format == IMX_VPU_CODEC_FORMAT_MJPEG)
-        {
+		/* Set default rotator settings for motion JPEG */
+		if (encoder->codec_format == IMX_VPU_CODEC_FORMAT_MJPEG)
+		{
 
 #       ifdef HAVE_ENC_ENABLE_SOF_STUFF
-            {
-                int append_nullbytes_to_sof_field = 0;
-                vpu_EncGiveCommand(encoder->handle, ENC_ENABLE_SOF_STUFF, (void*)(&append_nullbytes_to_sof_field));
-            }
+			{
+				int append_nullbytes_to_sof_field = 0;
+				vpu_EncGiveCommand(encoder->handle, ENC_ENABLE_SOF_STUFF, (void*)(&append_nullbytes_to_sof_field));
+			}
 #       endif
 	}
 	}

--- a/imxvpuapi/imxvpuapi_vpulib.c
+++ b/imxvpuapi/imxvpuapi_vpulib.c
@@ -60,13 +60,13 @@
 #define MIN_NUM_FREE_FB_REQUIRED 5
 #define FRAME_ALIGN 16
 
-#define VPU_MEMORY_ALIGNMENT         0x8
+#define VPU_MEMORY_ALIGNMENT		 0x8
 #define VPU_DEC_MAIN_BITSTREAM_BUFFER_SIZE (1024*1024*3)
 #define VPU_ENC_MAIN_BITSTREAM_BUFFER_SIZE (1024*1024*1)
-#define VPU_ENC_MPEG4_SCRATCH_SIZE         0x080000
-#define VPU_MAX_SLICE_BUFFER_SIZE          (1920*1088*15/20)
-#define VPU_PS_SAVE_BUFFER_SIZE            (1024*512)
-#define VPU_VP8_MB_PRED_BUFFER_SIZE        (68*(1920*1088/256))
+#define VPU_ENC_MPEG4_SCRATCH_SIZE		 0x080000
+#define VPU_MAX_SLICE_BUFFER_SIZE		  (1920*1088*15/20)
+#define VPU_PS_SAVE_BUFFER_SIZE			(1024*512)
+#define VPU_VP8_MB_PRED_BUFFER_SIZE		(68*(1920*1088/256))
 
 /* The decoder's bitstream buffer shares space with other fields,
  * to not have to allocate several DMA blocks. The actual bitstream buffer is called
@@ -80,15 +80,17 @@
 #define VPU_ENC_NUM_EXTRA_SUBSAMPLE_FRAMEBUFFERS  2
 
 #define VP8_SEQUENCE_HEADER_SIZE  32
-#define VP8_FRAME_HEADER_SIZE     12
+#define VP8_FRAME_HEADER_SIZE	 12
 
 #define WMV3_RCV_SEQUENCE_LAYER_SIZE (6 * 4)
-#define WMV3_RCV_FRAME_LAYER_SIZE    4
+#define WMV3_RCV_FRAME_LAYER_SIZE	4
 
 #define VC1_NAL_FRAME_LAYER_MAX_SIZE   4
 
-#define VPU_WAIT_TIMEOUT             8 /* milliseconds to wait for frame completion */
-#define VPU_MAX_TIMEOUT_COUNTS       128   /* how many timeouts are allowed in series */
+#define VPU_RB_WAIT_TIMEOUT			 10 /* milliseconds to wait for frame completion */
+#define VPU_RB_MAX_TIMEOUT_COUNTS	   64   /* how many timeouts are allowed in series */
+#define VPU_WAIT_TIMEOUT  (VPU_RB_WAIT_TIMEOUT*50)
+#define VPU_MAX_TIMEOUT_COUNTS 4
 
 #define MJPEG_ENC_HEADER_DATA_MAX_SIZE  2048
 
@@ -454,7 +456,7 @@ typedef struct
 	 * the value in mem_desc is potentially larger due to alignment */
 	size_t size;
 
-	uint8_t*            aligned_virtual_address;
+	uint8_t*			aligned_virtual_address;
 	imx_vpu_phys_addr_t aligned_physical_address;
 }
 DefaultDMABuffer;
@@ -665,9 +667,9 @@ void imx_vpu_calc_framebuffer_sizes(ImxVpuColorFormat color_format, unsigned int
 	 * while in the chroma_interleave == 1 case, there is one shared chroma plane
 	 * for both Cb and Cr data, with cbcr_size bytes */
 	calculated_sizes->total_size = calculated_sizes->y_size
-	                             + (chroma_interleave ? calculated_sizes->cbcr_size : (calculated_sizes->cbcr_size * 2))
-	                             + calculated_sizes->mvcol_size
-	                             + alignment;
+								 + (chroma_interleave ? calculated_sizes->cbcr_size : (calculated_sizes->cbcr_size * 2))
+								 + calculated_sizes->mvcol_size
+								 + alignment;
 
 	calculated_sizes->chroma_interleave = chroma_interleave;
 }
@@ -699,7 +701,7 @@ void imx_vpu_fill_framebuffer_params(ImxVpuFramebuffer *framebuffer, ImxVpuFrame
 
 /* Frames are not just occupied or free. They can be in one of three modes:
  * - FrameMode_Free: framebuffer is not being used for decoding, and does not hold
-     a displayable frame
+	 a displayable frame
  * - FrameMode_ReservedForDecoding: framebuffer contains frame data that is
  *   being decoded; this data can not be displayed yet though
  * - FrameMode_ContainsDisplayableFrame: framebuffer contains frame that has
@@ -903,16 +905,16 @@ char const * imx_vpu_dec_error_string(ImxVpuDecReturnCodes code)
 {
 	switch (code)
 	{
-		case IMX_VPU_DEC_RETURN_CODE_OK:                        return "ok";
-		case IMX_VPU_DEC_RETURN_CODE_ERROR:                     return "unspecified error";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_PARAMS:            return "invalid params";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_HANDLE:            return "invalid handle";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_FRAMEBUFFER:       return "invalid framebuffer";
+		case IMX_VPU_DEC_RETURN_CODE_OK:						return "ok";
+		case IMX_VPU_DEC_RETURN_CODE_ERROR:					 return "unspecified error";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_PARAMS:			return "invalid params";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_HANDLE:			return "invalid handle";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_FRAMEBUFFER:	   return "invalid framebuffer";
 		case IMX_VPU_DEC_RETURN_CODE_INSUFFICIENT_FRAMEBUFFERS: return "insufficient framebuffers";
-		case IMX_VPU_DEC_RETURN_CODE_INVALID_STRIDE:            return "invalid stride";
-		case IMX_VPU_DEC_RETURN_CODE_WRONG_CALL_SEQUENCE:       return "wrong call sequence";
-		case IMX_VPU_DEC_RETURN_CODE_TIMEOUT:                   return "timeout";
-		case IMX_VPU_DEC_RETURN_CODE_ALREADY_CALLED:            return "already called";
+		case IMX_VPU_DEC_RETURN_CODE_INVALID_STRIDE:			return "invalid stride";
+		case IMX_VPU_DEC_RETURN_CODE_WRONG_CALL_SEQUENCE:	   return "wrong call sequence";
+		case IMX_VPU_DEC_RETURN_CODE_TIMEOUT:				   return "timeout";
+		case IMX_VPU_DEC_RETURN_CODE_ALREADY_CALLED:			return "already called";
 		default: return "<unknown>";
 	}
 }
@@ -2178,8 +2180,8 @@ ImxVpuDecReturnCodes imx_vpu_dec_decode(ImxVpuDecoder *decoder, ImxVpuEncodedFra
 		  (((*output_code) & IMX_VPU_DEC_OUTPUT_CODE_NOT_ENOUGH_INPUT_DATA) == 0) &&
 		  (decoder->dec_output_info.indexFrameDecoded == VPU_DECODER_DECODEIDX_FRAME_NOT_DECODED) &&
 		  (
-		    (decoder->dec_output_info.indexFrameDisplay == VPU_DECODER_DISPLAYIDX_NO_FRAME_TO_DISPLAY) ||
-		    (decoder->dec_output_info.indexFrameDisplay == VPU_DECODER_DISPLAYIDX_SKIP_MODE_NO_FRAME_TO_DISPLAY)
+			(decoder->dec_output_info.indexFrameDisplay == VPU_DECODER_DISPLAYIDX_NO_FRAME_TO_DISPLAY) ||
+			(decoder->dec_output_info.indexFrameDisplay == VPU_DECODER_DISPLAYIDX_SKIP_MODE_NO_FRAME_TO_DISPLAY)
 		  )
 		)
 		{
@@ -2449,8 +2451,8 @@ struct _ImxVpuEncoder
 
 struct _ImxWriteParams
 {
-    uint8_t *write_ptr, *write_ptr_start, *write_ptr_end;
-    size_t mjpeg_header_size;
+	uint8_t *write_ptr, *write_ptr_start, *write_ptr_end;
+	size_t mjpeg_header_size;
 };
 
 
@@ -2771,15 +2773,15 @@ char const * imx_vpu_enc_error_string(ImxVpuEncReturnCodes code)
 {
 	switch (code)
 	{
-		case IMX_VPU_ENC_RETURN_CODE_OK:                        return "ok";
-		case IMX_VPU_ENC_RETURN_CODE_ERROR:                     return "unspecified error";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_PARAMS:            return "invalid params";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_HANDLE:            return "invalid handle";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_FRAMEBUFFER:       return "invalid framebuffer";
+		case IMX_VPU_ENC_RETURN_CODE_OK:						return "ok";
+		case IMX_VPU_ENC_RETURN_CODE_ERROR:					 return "unspecified error";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_PARAMS:			return "invalid params";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_HANDLE:			return "invalid handle";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_FRAMEBUFFER:	   return "invalid framebuffer";
 		case IMX_VPU_ENC_RETURN_CODE_INSUFFICIENT_FRAMEBUFFERS: return "insufficient framebuffers";
-		case IMX_VPU_ENC_RETURN_CODE_INVALID_STRIDE:            return "invalid stride";
-		case IMX_VPU_ENC_RETURN_CODE_WRONG_CALL_SEQUENCE:       return "wrong call sequence";
-		case IMX_VPU_ENC_RETURN_CODE_TIMEOUT:                   return "timeout";
+		case IMX_VPU_ENC_RETURN_CODE_INVALID_STRIDE:			return "invalid stride";
+		case IMX_VPU_ENC_RETURN_CODE_WRONG_CALL_SEQUENCE:	   return "wrong call sequence";
+		case IMX_VPU_ENC_RETURN_CODE_TIMEOUT:				   return "timeout";
 		default: return "<unknown>";
 	}
 }
@@ -2790,103 +2792,103 @@ char const * imx_vpu_enc_error_string(ImxVpuEncReturnCodes code)
 static int
 imx_vpu_enc_readbs_ring_buffer(ImxVpuEncoder *encoder, ImxVpuEncParams *encoding_params, ImxVpuRawFrame const *raw_frame)
 {
-    RetCode ret;
-    int space = 0, room;
-    PhysicalAddress pa_read_ptr, pa_write_ptr;
-    uint8_t *target_addr;
-    uint8_t *bs_va_endaddr;
-    uint32_t size;
+	RetCode ret;
+	int space = 0, room;
+	PhysicalAddress pa_read_ptr, pa_write_ptr;
+	uint8_t *target_addr;
+	uint8_t *bs_va_endaddr;
+	uint32_t size;
 
-    bs_va_endaddr = encoder->bitstream_buffer_virtual_address + VPU_ENC_MAIN_BITSTREAM_BUFFER_SIZE;
+	bs_va_endaddr = encoder->bitstream_buffer_virtual_address + VPU_ENC_MAIN_BITSTREAM_BUFFER_SIZE;
 
-    ret = vpu_EncGetBitstreamBuffer(encoder->handle, &pa_read_ptr, &pa_write_ptr,
-                    (Uint32 *)&size);
-    if (ret != RETCODE_SUCCESS) {
-        IMX_VPU_ERROR("EncGetBitstreamBuffer failed");
-        return -1;
-    }
+	ret = vpu_EncGetBitstreamBuffer(encoder->handle, &pa_read_ptr, &pa_write_ptr,
+					(Uint32 *)&size);
+	if (ret != RETCODE_SUCCESS) {
+		IMX_VPU_ERROR("EncGetBitstreamBuffer failed");
+		return -1;
+	}
 
-    /* No space in ring buffer */
-    if (size <= 0)
-        return 0;
+	/* No space in ring buffer */
+	if (size <= 0)
+		return 0;
 
-    space = size;
+	space = size;
 
-    target_addr = encoder->bitstream_buffer_virtual_address + (pa_read_ptr - encoder->bitstream_buffer_physical_address);
-    if ( (target_addr + space) > bs_va_endaddr) {
-        room = bs_va_endaddr - target_addr;
-        encoding_params->write_output_buffer(encoding_params->output_buffer_context, target_addr, room, raw_frame->pts, raw_frame->dts);
-        encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->bitstream_buffer_virtual_address, (space - room), raw_frame->pts, raw_frame->dts);
-    } else {
-        encoding_params->write_output_buffer(encoding_params->output_buffer_context, target_addr, space, raw_frame->pts, raw_frame->dts);
-    }
+	target_addr = encoder->bitstream_buffer_virtual_address + (pa_read_ptr - encoder->bitstream_buffer_physical_address);
+	if ( (target_addr + space) > bs_va_endaddr) {
+		room = bs_va_endaddr - target_addr;
+		encoding_params->write_output_buffer(encoding_params->output_buffer_context, target_addr, room, raw_frame->pts, raw_frame->dts);
+		encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->bitstream_buffer_virtual_address, (space - room), raw_frame->pts, raw_frame->dts);
+	} else {
+		encoding_params->write_output_buffer(encoding_params->output_buffer_context, target_addr, space, raw_frame->pts, raw_frame->dts);
+	}
 
-    ret = vpu_EncUpdateBitstreamBuffer(encoder->handle, space);
-    if (ret != RETCODE_SUCCESS) {
-        IMX_VPU_ERROR("EncUpdateBitstreamBuffer failed");
-        return -1;
-    }
+	ret = vpu_EncUpdateBitstreamBuffer(encoder->handle, space);
+	if (ret != RETCODE_SUCCESS) {
+		IMX_VPU_ERROR("EncUpdateBitstreamBuffer failed");
+		return -1;
+	}
 
-    return space;
+	return space;
 }
 
 static void imx_vpu_enc_write_header_data(ImxVpuEncoder *encoder, ImxVpuRawFrame const *raw_frame, ImxVpuEncParams *encoding_params, struct _ImxWriteParams *write_params, unsigned int *output_code)
 {
 
 #define ADD_HEADER_DATA(HEADER_FIELD, DESCRIPTION) \
-        do \
-        { \
-            size_t size = encoder->headers.HEADER_FIELD ## _size; \
-            if(NULL == encoding_params->write_output_buffer) \
-            { \
-                memcpy(write_params->write_ptr, encoder->headers.HEADER_FIELD, size); \
-                write_params->write_ptr += size; \
-            } \
-            else \
-            { \
-                encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.HEADER_FIELD, size, raw_frame->pts, raw_frame->dts); \
-            } \
-            IMX_VPU_LOG("added %s with %zu byte", (DESCRIPTION), size); \
-        } \
-        while (0)
+		do \
+		{ \
+			size_t size = encoder->headers.HEADER_FIELD ## _size; \
+			if(NULL == encoding_params->write_output_buffer) \
+			{ \
+				memcpy(write_params->write_ptr, encoder->headers.HEADER_FIELD, size); \
+				write_params->write_ptr += size; \
+			} \
+			else \
+			{ \
+				encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.HEADER_FIELD, size, raw_frame->pts, raw_frame->dts); \
+			} \
+			IMX_VPU_LOG("added %s with %zu byte", (DESCRIPTION), size); \
+		} \
+		while (0)
 
-    switch (encoder->codec_format)
-    {
-        case IMX_VPU_CODEC_FORMAT_H264:
-        {
-            ADD_HEADER_DATA(h264_headers.sps_rbsp, "h.264 SPS RBSP");
-            ADD_HEADER_DATA(h264_headers.pps_rbsp, "h.264 PPS RBSP");
-            break;
-        }
+	switch (encoder->codec_format)
+	{
+		case IMX_VPU_CODEC_FORMAT_H264:
+		{
+			ADD_HEADER_DATA(h264_headers.sps_rbsp, "h.264 SPS RBSP");
+			ADD_HEADER_DATA(h264_headers.pps_rbsp, "h.264 PPS RBSP");
+			break;
+		}
 
-        case IMX_VPU_CODEC_FORMAT_MPEG4:
-        {
-            ADD_HEADER_DATA(mpeg4_headers.vos_header, "MPEG-4 VOS header");
-            ADD_HEADER_DATA(mpeg4_headers.vis_header, "MPEG-4 VIS header");
-            ADD_HEADER_DATA(mpeg4_headers.vol_header, "MPEG-4 VOL header");
-            break;
-        }
+		case IMX_VPU_CODEC_FORMAT_MPEG4:
+		{
+			ADD_HEADER_DATA(mpeg4_headers.vos_header, "MPEG-4 VOS header");
+			ADD_HEADER_DATA(mpeg4_headers.vis_header, "MPEG-4 VIS header");
+			ADD_HEADER_DATA(mpeg4_headers.vol_header, "MPEG-4 VOL header");
+			break;
+		}
 
-        case IMX_VPU_CODEC_FORMAT_MJPEG:
-        {
-            if(NULL == encoding_params->write_output_buffer)
-            {
-                memcpy(write_params->write_ptr, encoder->headers.mjpeg_header_data, write_params->mjpeg_header_size);
-                write_params->write_ptr +=write_params->mjpeg_header_size;
-            }
-            else
-            {
-                encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.mjpeg_header_data, write_params->mjpeg_header_size, raw_frame->pts, raw_frame->dts);
-            }
-            IMX_VPU_LOG("added JPEG header with %zu byte", write_params->mjpeg_header_size);
-            break;
-        }
+		case IMX_VPU_CODEC_FORMAT_MJPEG:
+		{
+			if(NULL == encoding_params->write_output_buffer)
+			{
+				memcpy(write_params->write_ptr, encoder->headers.mjpeg_header_data, write_params->mjpeg_header_size);
+				write_params->write_ptr +=write_params->mjpeg_header_size;
+			}
+			else
+			{
+				encoding_params->write_output_buffer(encoding_params->output_buffer_context, encoder->headers.mjpeg_header_data, write_params->mjpeg_header_size, raw_frame->pts, raw_frame->dts);
+			}
+			IMX_VPU_LOG("added JPEG header with %zu byte", write_params->mjpeg_header_size);
+			break;
+		}
 
-        default:
-            break;
-    }
+		default:
+			break;
+	}
 
-    *output_code |= IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER;
+	*output_code |= IMX_VPU_ENC_OUTPUT_CODE_CONTAINS_HEADER;
 #undef ADD_HEADER_DATA
 
 }
@@ -3582,22 +3584,22 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 #define GET_BITSTREAM_VIRT_ADDR(BITSTREAM_PHYS_ADDR) (encoder->bitstream_buffer_virtual_address + ((BITSTREAM_PHYS_ADDR) - encoder->bitstream_buffer_physical_address))
 
 #define WRITE_AUD() \
-    do{ \
-        if(NULL == encoding_params->write_output_buffer) \
-        { \
-            memcpy(write_params.write_ptr, h264_aud, sizeof(h264_aud)); \
-            write_params.write_ptr += sizeof(h264_aud); \
-        } \
-        else \
-        { \
-            encoding_params->write_output_buffer(encoding_params->output_buffer_context, h264_aud, sizeof(h264_aud), raw_frame->pts, raw_frame->dts); \
-        } \
-    }while(0)
+	do{ \
+		if(NULL == encoding_params->write_output_buffer) \
+		{ \
+			memcpy(write_params.write_ptr, h264_aud, sizeof(h264_aud)); \
+			write_params.write_ptr += sizeof(h264_aud); \
+		} \
+		else \
+		{ \
+			encoding_params->write_output_buffer(encoding_params->output_buffer_context, h264_aud, sizeof(h264_aud), raw_frame->pts, raw_frame->dts); \
+		} \
+	}while(0)
 
 
-    uint8_t const h264_aud[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0xF0 };
+	uint8_t const h264_aud[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0xF0 };
 
-    ImxVpuEncReturnCodes ret;
+	ImxVpuEncReturnCodes ret;
 	RetCode enc_ret;
 	EncParam enc_param;
 	EncOutputInfo enc_output_info;
@@ -3689,36 +3691,36 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 
 	if(encoder->ring_buffer_mode)
 	{
-	    /* We are in streaming mode - The header should be written before the frame is complete or any part of it for that matter */
-	    /* Check to see if an header should be added to the output */
-	    switch (encoder->codec_format)
-	    {
-	        case IMX_VPU_CODEC_FORMAT_MJPEG:
-	        {
-	            add_header = TRUE;
-	            break;
-	        }
+		/* We are in streaming mode - The header should be written before the frame is complete or any part of it for that matter */
+		/* Check to see if an header should be added to the output */
+		switch (encoder->codec_format)
+		{
+			case IMX_VPU_CODEC_FORMAT_MJPEG:
+			{
+				add_header = TRUE;
+				break;
+			}
 
-	        case IMX_VPU_CODEC_FORMAT_H264:
-	        case IMX_VPU_CODEC_FORMAT_MPEG4:
-	            add_header = encoder->first_frame || encoding_params->force_I_frame || encoder->gop_monitor == 0;
-	            break;
+			case IMX_VPU_CODEC_FORMAT_H264:
+			case IMX_VPU_CODEC_FORMAT_MPEG4:
+				add_header = encoder->first_frame || encoding_params->force_I_frame || encoder->gop_monitor == 0;
+				break;
 
-	        default:
-	            add_header = FALSE;
-	    }
+			default:
+				add_header = FALSE;
+		}
 
-	    /* AUD should come before SPS/PPS - see the code in
-         * imx_vpu_enc_open() for details */
-	    if(encoder->aud_enable)
-	    {
-	        WRITE_AUD();
-	        IMX_VPU_LOG("added h.264 AUD");
-	    }
-	    if(add_header)
-	    {
-	        imx_vpu_enc_write_header_data(encoder, raw_frame, encoding_params, &write_params, output_code);
-	    }
+		/* AUD should come before SPS/PPS - see the code in
+		 * imx_vpu_enc_open() for details */
+		if(encoder->aud_enable)
+		{
+			WRITE_AUD();
+			IMX_VPU_LOG("added h.264 AUD");
+		}
+		if(add_header)
+		{
+			imx_vpu_enc_write_header_data(encoder, raw_frame, encoding_params, &write_params, output_code);
+		}
 	}
 
 	/* Wait for frame completion */
@@ -3727,34 +3729,46 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 
 		IMX_VPU_LOG("waiting for encoding completion");
 
-		/* Wait a few times, since sometimes, it takes more than
-		 * one vpu_WaitForInt() call to cover the encoding interval */
-		timeout = TRUE;
-		for (cnt = 0; cnt < VPU_MAX_TIMEOUT_COUNTS; ++cnt)
+		if(encoder->ring_buffer_mode)
 		{
-			if (vpu_WaitForInt(VPU_WAIT_TIMEOUT) != RETCODE_SUCCESS)
+			/* Wait a few times, since sometimes, it takes more than
+			 * one vpu_WaitForInt() call to cover the encoding interval */
+			timeout = FALSE;
+			cnt = 0;
+			while (vpu_WaitForInt(VPU_RB_WAIT_TIMEOUT) != RETCODE_SUCCESS)
 			{
-			    if(encoder->ring_buffer_mode)
-			    {
-			        if(0 > imx_vpu_enc_readbs_ring_buffer(encoder, encoding_params, raw_frame))
-			        {
-			            IMX_VPU_ERROR("Unable to read ring buffer");
-			            timeout = false;
-			            break;
-			        }
-			    }
-			    usleep(VPU_WAIT_TIMEOUT*1000);
-			}
-			else
-			{
-				timeout = FALSE;
-				break;
-			}
-			if(cnt > 0 && 0 == (cnt & 63))
-			{
-                IMX_VPU_INFO("timeout after waiting %d ms for frame completion", VPU_WAIT_TIMEOUT*64);
+				while(0 < imx_vpu_enc_readbs_ring_buffer(encoder, encoding_params, raw_frame))
+				{
+					usleep(VPU_RB_WAIT_TIMEOUT*1000);
+				}
+				cnt++;
+				if(cnt == VPU_MAX_TIMEOUT_COUNTS)
+				{
+					IMX_VPU_INFO("timeout after waiting (aprox.) %d ms for frame completion", VPU_RB_WAIT_TIMEOUT*VPU_RB_MAX_TIMEOUT_COUNTS);
+  				  timeout = TRUE;
+					break;
+				}
 			}
 		}
+		else
+		{
+			timeout = TRUE;
+			/* Wait a few times, since sometimes, it takes more than
+			 * one vpu_WaitForInt() call to cover the encoding interval */
+			for(cnt = 0; cnt < VPU_MAX_TIMEOUT_COUNTS; cnt++)
+			{
+				if(vpu_WaitForInt(VPU_WAIT_TIMEOUT) != RETCODE_SUCCESS)
+				{
+					continue;
+				}
+				else
+				{
+					timeout = FALSE;
+					break;
+				}
+			}
+		}
+
 	}
 
 	/* Retrieve information about the result of the encode process. Do so even if
@@ -3799,113 +3813,113 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 
 	if(encoder->ring_buffer_mode)
 	{
-        if(0 <= imx_vpu_enc_readbs_ring_buffer(encoder, encoding_params, raw_frame))
-        {
-            *output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
-        }
+		if(0 <= imx_vpu_enc_readbs_ring_buffer(encoder, encoding_params, raw_frame))
+		{
+			*output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
+		}
 	}
 	else
 	{
-	    /* Check to see if an header should be added to the output */
-	    switch (encoder->codec_format)
-	    {
-	        case IMX_VPU_CODEC_FORMAT_MJPEG:
-	        {
-	            add_header = TRUE;
-	            break;
-	        }
+		/* Check to see if an header should be added to the output */
+		switch (encoder->codec_format)
+		{
+			case IMX_VPU_CODEC_FORMAT_MJPEG:
+			{
+				add_header = TRUE;
+				break;
+			}
 
-	        case IMX_VPU_CODEC_FORMAT_H264:
-	        case IMX_VPU_CODEC_FORMAT_MPEG4:
-	            add_header = encoder->first_frame || encoding_params->force_I_frame || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_IDR) || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_I);
-	            break;
+			case IMX_VPU_CODEC_FORMAT_H264:
+			case IMX_VPU_CODEC_FORMAT_MPEG4:
+				add_header = encoder->first_frame || encoding_params->force_I_frame || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_IDR) || (encoded_frame->frame_type == IMX_VPU_FRAME_TYPE_I);
+				break;
 
-	        default:
-	            add_header = FALSE;
-	    }
+			default:
+				add_header = FALSE;
+		}
 
-	    encoded_data_size = enc_output_info.bitstreamSize;
-        if (encoder->aud_enable)
-            encoded_data_size += sizeof(h264_aud);
+		encoded_data_size = enc_output_info.bitstreamSize;
+		if (encoder->aud_enable)
+			encoded_data_size += sizeof(h264_aud);
 
-        if (add_header)
-        {
-            switch (encoder->codec_format)
-            {
-                case IMX_VPU_CODEC_FORMAT_MJPEG:
-                    encoded_data_size += write_params.mjpeg_header_size;
-                    break;
+		if (add_header)
+		{
+			switch (encoder->codec_format)
+			{
+				case IMX_VPU_CODEC_FORMAT_MJPEG:
+					encoded_data_size += write_params.mjpeg_header_size;
+					break;
 
-                case IMX_VPU_CODEC_FORMAT_H264:
-                    encoded_data_size += encoder->headers.h264_headers.sps_rbsp_size + encoder->headers.h264_headers.pps_rbsp_size;
-                    break;
+				case IMX_VPU_CODEC_FORMAT_H264:
+					encoded_data_size += encoder->headers.h264_headers.sps_rbsp_size + encoder->headers.h264_headers.pps_rbsp_size;
+					break;
 
-                case IMX_VPU_CODEC_FORMAT_MPEG4:
-                    encoded_data_size += encoder->headers.mpeg4_headers.vos_header_size + encoder->headers.mpeg4_headers.vis_header_size + encoder->headers.mpeg4_headers.vol_header_size;
-                    break;
+				case IMX_VPU_CODEC_FORMAT_MPEG4:
+					encoded_data_size += encoder->headers.mpeg4_headers.vos_header_size + encoder->headers.mpeg4_headers.vis_header_size + encoder->headers.mpeg4_headers.vol_header_size;
+					break;
 
-                default:
-                    break;
-            }
-        }
+				default:
+					break;
+			}
+		}
 
-        encoded_frame->data_size = encoded_data_size;
-        if(NULL == encoding_params->write_output_buffer)
-        {
-            write_params.write_ptr_start = encoding_params->acquire_output_buffer(encoding_params->output_buffer_context, encoded_data_size, &(encoded_frame->acquired_handle));
-            if (write_params.write_ptr_start == NULL)
-            {
-                IMX_VPU_ERROR("could not acquire buffer with %zu byte for encoded frame data", encoded_data_size);
-                ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
-                goto finish;
-            }
+		encoded_frame->data_size = encoded_data_size;
+		if(NULL == encoding_params->write_output_buffer)
+		{
+			write_params.write_ptr_start = encoding_params->acquire_output_buffer(encoding_params->output_buffer_context, encoded_data_size, &(encoded_frame->acquired_handle));
+			if (write_params.write_ptr_start == NULL)
+			{
+				IMX_VPU_ERROR("could not acquire buffer with %zu byte for encoded frame data", encoded_data_size);
+				ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
+				goto finish;
+			}
 
-            write_params.write_ptr = write_params.write_ptr_start;
-            write_params.write_ptr_end = write_params.write_ptr + encoded_data_size;
-        }
+			write_params.write_ptr = write_params.write_ptr_start;
+			write_params.write_ptr_end = write_params.write_ptr + encoded_data_size;
+		}
 
-        /* AUD should come before SPS/PPS - see the code in
-         * imx_vpu_enc_open() for details */
-        if(encoder->aud_enable)
-        {
-            WRITE_AUD();
-            IMX_VPU_LOG("added h.264 AUD");
-        }
-        if(add_header)
-        {
-            imx_vpu_enc_write_header_data(encoder, raw_frame, encoding_params, &write_params, output_code);
-        }
-        /* Get the encoded data out of the bitstream buffer into the output buffer */
-        if (enc_output_info.bitstreamBuffer != 0)
-        {
-            uint8_t const *output_data_ptr = GET_BITSTREAM_VIRT_ADDR(enc_output_info.bitstreamBuffer);
+		/* AUD should come before SPS/PPS - see the code in
+		 * imx_vpu_enc_open() for details */
+		if(encoder->aud_enable)
+		{
+			WRITE_AUD();
+			IMX_VPU_LOG("added h.264 AUD");
+		}
+		if(add_header)
+		{
+			imx_vpu_enc_write_header_data(encoder, raw_frame, encoding_params, &write_params, output_code);
+		}
+		/* Get the encoded data out of the bitstream buffer into the output buffer */
+		if (enc_output_info.bitstreamBuffer != 0)
+		{
+			uint8_t const *output_data_ptr = GET_BITSTREAM_VIRT_ADDR(enc_output_info.bitstreamBuffer);
 
-            if(NULL == encoding_params->write_output_buffer)
-            {
-                ptrdiff_t available_space = write_params.write_ptr_end - write_params.write_ptr;
+			if(NULL == encoding_params->write_output_buffer)
+			{
+				ptrdiff_t available_space = write_params.write_ptr_end - write_params.write_ptr;
 
-                if (available_space < (ptrdiff_t)(enc_output_info.bitstreamSize))
-                {
-                    IMX_VPU_ERROR(
-                        "insufficient space in output buffer for encoded data: need %u byte, got %td",
-                        enc_output_info.bitstreamSize,
-                        available_space
-                    );
-                    ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
+				if (available_space < (ptrdiff_t)(enc_output_info.bitstreamSize))
+				{
+					IMX_VPU_ERROR(
+						"insufficient space in output buffer for encoded data: need %u byte, got %td",
+						enc_output_info.bitstreamSize,
+						available_space
+					);
+					ret = IMX_VPU_ENC_RETURN_CODE_ERROR;
 
-                    goto finish;
-                }
-                memcpy(write_params.write_ptr, output_data_ptr, enc_output_info.bitstreamSize);
-                write_params.write_ptr += enc_output_info.bitstreamSize;
-            }
-            else
-            {
-                encoding_params->write_output_buffer(encoding_params->output_buffer_context, output_data_ptr, enc_output_info.bitstreamSize, raw_frame->pts, raw_frame->dts);
-            }
+					goto finish;
+				}
+				memcpy(write_params.write_ptr, output_data_ptr, enc_output_info.bitstreamSize);
+				write_params.write_ptr += enc_output_info.bitstreamSize;
+			}
+			else
+			{
+				encoding_params->write_output_buffer(encoding_params->output_buffer_context, output_data_ptr, enc_output_info.bitstreamSize, raw_frame->pts, raw_frame->dts);
+			}
 
-            IMX_VPU_LOG("added main encoded frame data with %u byte", enc_output_info.bitstreamSize);
-            *output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
-        }
+			IMX_VPU_LOG("added main encoded frame data with %u byte", enc_output_info.bitstreamSize);
+			*output_code |= IMX_VPU_ENC_OUTPUT_CODE_ENCODED_FRAME_AVAILABLE;
+		}
 	}
 
 	/* Add this flag since the raw frame has been successfully consumed */
@@ -3913,10 +3927,10 @@ ImxVpuEncReturnCodes imx_vpu_enc_encode(ImxVpuEncoder *encoder, ImxVpuRawFrame c
 
 	/* Increment the gop monitor. This is necessary to correctly insert headers in ring buffer mode */
 	++encoder->gop_monitor;
-    if(encoder->gop_monitor == encoder->gop_size)
-    {
-        encoder->gop_monitor = 0;
-    }
+	if(encoder->gop_monitor == encoder->gop_size)
+	{
+		encoder->gop_monitor = 0;
+	}
 
 
 	/* Since the encoder does not perform any kind of delay


### PR DESCRIPTION
… the user to allocate a buffer (zero copy). Add the total_size of a buffer to ImxVpuFrameBuffer

There are two changes in this commit:
The first and easy one is just adding the total_size to ImxVpuFrameBuffer. We need this internally to wrap the these buffers int our own memory allocator. Others may need this as well.

The second more interesting change is to allow directly calling a write style function instead of asking the user to supply an output buffer using acquire_output_buffer and releasing it using finish_output_buffer.
This enables several advantages:
1. No need for memory allocation while encoding or managing pre-allocated buffers
2. Zero copy (or at least let the user decide what type of copy she desires)
3. A possibility to directly write to a file descriptor (file,pipe,socket...)
