### PR TITLE
waf: use python3

### DIFF
--- a/waf
+++ b/waf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: latin-1
 # Thomas Nagy, 2005-2018
 #

--- a/wscript
+++ b/wscript
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 from waflib.Build import BuildContext, CleanContext, InstallContext, UninstallContext, Logs


### PR DESCRIPTION
In OE, with the removal of python2 from hosttools we have to use python3.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>