### PR TITLE
correctly usage of encoder pointer

### DIFF
--- a/imxvpuapi2/imxvpuapi2_imx6_coda.c
+++ b/imxvpuapi2/imxvpuapi2_imx6_coda.c
@@ -3296,7 +3296,7 @@ ImxVpuApiEncReturnCodes imx_vpu_api_enc_open(ImxVpuApiEncoder **encoder, ImxVpuA
 #ifdef HAVE_ENC_ENABLE_SOF_STUFF
 		{
 			int append_nullbytes_to_sof_field = 0;
-			vpu_EncGiveCommand(encoder->handle, ENC_ENABLE_SOF_STUFF, (void*)(&append_nullbytes_to_sof_field));
+			vpu_EncGiveCommand((*encoder)->handle, ENC_ENABLE_SOF_STUFF, (void*)(&append_nullbytes_to_sof_field));
 		}
 #endif
 	}


### PR DESCRIPTION
while compling the 2.0.0 on my platform I got the following error

external/libimxvpuapi/imxvpuapi2/imxvpuapi2_imx6_coda.c:3299:30: error: request for member 'handle' in something not a structure or union
    vpu_EncGiveCommand(encoder->handle, ENC_ENABLE_SOF_STUFF, (void*)(&append_nullbytes_to_sof_field));

this pull request corrects that issue and access the encoder as the other functions too
