### PR TITLE
Reset drain mode after EOS processed.

### DIFF
--- a/imxvpuapi2/imxvpuapi2_imx6_coda.c
+++ b/imxvpuapi2/imxvpuapi2_imx6_coda.c
@@ -2427,6 +2427,7 @@ ImxVpuApiDecReturnCodes imx_vpu_api_dec_decode(ImxVpuApiDecoder *decoder, ImxVpu
 		{
 			IMX_VPU_API_LOG("EOS reached");
 			decoder->available_decoded_frame_idx = -1;
+			decoder->drain_mode_enabled = FALSE;
 			*output_code = IMX_VPU_API_DEC_OUTPUT_CODE_EOS;
 		}
 		else


### PR DESCRIPTION
Not sure if this should be fixed here or in gstreamer-imx but since there currently isn't an API to disable drain mode I did it this way as a quick fix.

I'm looping the same video for 30min at a time (simple seek on eos) and it started to fail after upgrading to v2.
