### PR TITLE
imx8m-hantro: Reset decoder write_offset to fill_level when moving read_offset.

### DIFF
--- a/imxvpuapi2/imxvpuapi2_imx8m_hantro_decoder.c
+++ b/imxvpuapi2/imxvpuapi2_imx8m_hantro_decoder.c
@@ -441,7 +441,7 @@ static void imx_vpu_api_dec_push_input_data(ImxVpuApiDecoder *decoder, void cons
 		{
 			memmove(streambuf_bytes, streambuf_bytes + read_offset, fill_level);
 			decoder->stream_buffer_read_offset = 0;
-			decoder->stream_buffer_write_offset -= read_offset;
+			decoder->stream_buffer_write_offset = fill_level;
 			memcpy(streambuf_bytes + decoder->stream_buffer_write_offset, src_data_bytes, data_size);
 			decoder->stream_buffer_write_offset += data_size;
 		}


### PR DESCRIPTION
With the right timing, it's possible to have the read side all caught up and the write side at the end of the buffer. This will cause the `memmove()` to move `0` bytes and the write offset to be reduced by `0`, leading to a `SIGSEGV` in the `memcpy()` as we try to write after the buffer.

Signed-off-by: Doug Nazar <nazard@nazar.ca>