### PR TITLE
Implement imx_vpu_api_enc_get_skipped_frame_info() and imx_vpu_api_enc_get_encoded_frame_ext() stubs for all encoders

### DIFF
--- a/imxvpuapi2/imxvpuapi2_imx6_coda.c
+++ b/imxvpuapi2/imxvpuapi2_imx6_coda.c
@@ -4196,4 +4196,6 @@ ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_skipped_frame_info(ImxVpuApiEncoder 
 	IMX_VPU_API_UNUSED_PARAM(dts);
 
 	/* TODO: Frameskipping with CODA960 is not supported at this point */
+
+	return IMX_VPU_API_ENC_RETURN_CODE_INVALID_CALL;
 }

--- a/imxvpuapi2/imxvpuapi2_imx8m_hantro_dummy_encoder.c
+++ b/imxvpuapi2/imxvpuapi2_imx8m_hantro_dummy_encoder.c
@@ -126,3 +126,13 @@ ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_encoded_frame(ImxVpuApiEncoder *enco
 	IMX_VPU_API_UNUSED_PARAM(encoded_frame);
 	return IMX_VPU_API_ENC_RETURN_CODE_OK;
 }
+
+ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_skipped_frame_info(ImxVpuApiEncoder *encoder, void **context, uint64_t *pts, uint64_t *dts)
+{
+	IMX_VPU_API_UNUSED_PARAM(encoder);
+	IMX_VPU_API_UNUSED_PARAM(context);
+	IMX_VPU_API_UNUSED_PARAM(pts);
+	IMX_VPU_API_UNUSED_PARAM(dts);
+
+	return IMX_VPU_API_ENC_RETURN_CODE_INVALID_CALL;
+}

--- a/imxvpuapi2/imxvpuapi2_imx8m_hantro_dummy_encoder.c
+++ b/imxvpuapi2/imxvpuapi2_imx8m_hantro_dummy_encoder.c
@@ -119,11 +119,16 @@ ImxVpuApiEncReturnCodes imx_vpu_api_enc_encode(ImxVpuApiEncoder *encoder, size_t
 	return IMX_VPU_API_ENC_RETURN_CODE_OK;
 }
 
-
 ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_encoded_frame(ImxVpuApiEncoder *encoder, ImxVpuApiEncodedFrame *encoded_frame)
+{
+	return imx_vpu_api_enc_get_encoded_frame_ext(encoder, encoded_frame, NULL);
+}
+
+ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_encoded_frame_ext(ImxVpuApiEncoder *encoder, ImxVpuApiEncodedFrame *encoded_frame, int *is_sync_point)
 {
 	IMX_VPU_API_UNUSED_PARAM(encoder);
 	IMX_VPU_API_UNUSED_PARAM(encoded_frame);
+	IMX_VPU_API_UNUSED_PARAM(is_sync_point);
 	return IMX_VPU_API_ENC_RETURN_CODE_OK;
 }
 

--- a/imxvpuapi2/imxvpuapi2_imx8m_hantro_vc8000_encoder.c
+++ b/imxvpuapi2/imxvpuapi2_imx8m_hantro_vc8000_encoder.c
@@ -1426,3 +1426,15 @@ ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_encoded_frame_ext(ImxVpuApiEncoder *
 
 	return IMX_VPU_API_ENC_RETURN_CODE_OK;
 }
+
+ImxVpuApiEncReturnCodes imx_vpu_api_enc_get_skipped_frame_info(ImxVpuApiEncoder *encoder, void **context, uint64_t *pts, uint64_t *dts)
+{
+	IMX_VPU_API_UNUSED_PARAM(encoder);
+	IMX_VPU_API_UNUSED_PARAM(context);
+	IMX_VPU_API_UNUSED_PARAM(pts);
+	IMX_VPU_API_UNUSED_PARAM(dts);
+
+	/* Frameskipping with VC8000 is not supported */
+
+	return IMX_VPU_API_ENC_RETURN_CODE_INVALID_CALL;
+}


### PR DESCRIPTION
The imx_vpu_api_enc_get_skipped_frame_info and imx_vpu_api_enc_get_encoded_frame_ext must be available during linking of current gstreamer-imx. Make these symbols available for all encoders.

For imx_vpu_api_enc_get_skipped_frame_info(), a stub implementation is added that always returns `IMX_VPU_API_ENC_RETURN_CODE_INVALID_CALL` (and the stub for imx6-coda is fixed to have a return value at all to avoid a compiler warning).

imx_vpu_api_enc_get_encoded_frame_ext() was only missing for imx8m-hantro dummy_encoder.

Fixes https://github.com/Freescale/gstreamer-imx/issues/328